### PR TITLE
Fix incorrect links

### DIFF
--- a/docs/learn/intro.md
+++ b/docs/learn/intro.md
@@ -36,7 +36,7 @@ Choose one of the following methods to **start farming** on the Network (from ea
 
 Farmers can nominate **operators** and back them with their tokens, increasing their stake and chance of being elected as slot leaders. Generally speaking, any SSC token holder can stake their tokens by **nominating** a domain operator without having to become an operator or farmer themselves. **Nominators** earn **staking** rewards, proportional to their **staking amount** and pay the operator a pre-agreed **tax** on them.
 
-#### - [Start Nominating](/docs/farming-&-staking/staking/intro.md)
+#### - [Start Nominating](/docs/farming-&-staking/staking/staking.md)
 
 ### **Become an operator**
 

--- a/docs/learn/intro.md
+++ b/docs/learn/intro.md
@@ -36,19 +36,19 @@ Choose one of the following methods to **start farming** on the Network (from ea
 
 Farmers can nominate **operators** and back them with their tokens, increasing their stake and chance of being elected as slot leaders. Generally speaking, any SSC token holder can stake their tokens by **nominating** a domain operator without having to become an operator or farmer themselves. **Nominators** earn **staking** rewards, proportional to their **staking amount** and pay the operator a pre-agreed **tax** on them.
 
-#### - [Start Nominating](../farming-&-staking/staking/)
+#### - [Start Nominating](/docs/farming-&-staking/staking/intro.md)
 
 ### **Become an operator**
 
 **Operators** are responsible for validating and executing transactions, producing execution receipts, applying state transitions and earn rewards for their work.
 
-#### - [Start an Opeator node](../farming-&-staking/staking/operators/register-operator)
+#### - [Start an Opeator node](/docs/farming-&-staking/staking/operators/register-operator.mdx)
 
 ### **Become a timekeeper**
 
 **Timekeepers** on the Subspace Network are responsible for running the **Proof-of-Time chain** and maintaining the randomness beacon for the **consensus chain**.
 
-#### - [Start timekeeping](../farming-&-staking/timekeeping)
+#### - [Start timekeeping](/docs/farming-&-staking/timekeeping.md)
 
 ## 📖 Develop on The Subspace Network
 ---
@@ -57,7 +57,7 @@ Farmers can nominate **operators** and back them with their tokens, increasing t
 
 The Subspace Network hosts an **EVM (Ethereum Virtual Machine)**, that allows you to deploy your **smart contracts.** 
 
-#### - [EVM Development](../develop/nova/intro)
+#### - [EVM Development](/docs/develop/nova/intro.md)
 
 ### Utilize the Core Protocol
 The Subspace Network aims to provide an amazing developer experience to anyone who wishes to build on top of the protocol. As such we have started working on a variety of tools to assist and promote development on our network. 

--- a/docs/learn/intro.md
+++ b/docs/learn/intro.md
@@ -29,8 +29,8 @@ The Subspace Network is an ambitious layer zero protocol which is the first scal
 
 Choose one of the following methods to **start farming** on the Network (from easy to more complex):
 
-#### - [Start Farming with Space Acres](../farming-&-staking/farming/space-acres/space-acres-install)
-#### - [Start Farming with Advanced CLI](../farming-&-staking/farming/advanced-cli/cli-install)
+#### - [Start Farming with Space Acres](/docs/farming-&-staking/farming/space-acres/space-acres-install.mdx)
+#### - [Start Farming with Advanced CLI](/docs/farming-&-staking/farming/advanced-cli/cli-install.mdx)
 
 ### **Become a nominator**
 

--- a/versioned_docs/version-latest/learn/intro.md
+++ b/versioned_docs/version-latest/learn/intro.md
@@ -36,7 +36,7 @@ Choose one of the following methods to **start farming** on the Network (from ea
 
 Farmers can nominate **operators** and back them with their tokens, increasing their stake and chance of being elected as slot leaders. Generally speaking, any SSC token holder can stake their tokens by **nominating** a domain operator without having to become an operator or farmer themselves. **Nominators** earn **staking** rewards, proportional to their **staking amount** and pay the operator a pre-agreed **tax** on them.
 
-#### - [Start Nominating](/docs/farming-&-staking/staking/intro.md)
+#### - [Start Nominating](/docs/farming-&-staking/staking/staking.md)
 
 ### **Become an operator**
 

--- a/versioned_docs/version-latest/learn/intro.md
+++ b/versioned_docs/version-latest/learn/intro.md
@@ -36,19 +36,19 @@ Choose one of the following methods to **start farming** on the Network (from ea
 
 Farmers can nominate **operators** and back them with their tokens, increasing their stake and chance of being elected as slot leaders. Generally speaking, any SSC token holder can stake their tokens by **nominating** a domain operator without having to become an operator or farmer themselves. **Nominators** earn **staking** rewards, proportional to their **staking amount** and pay the operator a pre-agreed **tax** on them.
 
-#### - [Start Nominating](../farming-&-staking/staking/)
+#### - [Start Nominating](/docs/farming-&-staking/staking/intro.md)
 
 ### **Become an operator**
 
 **Operators** are responsible for validating and executing transactions, producing execution receipts, applying state transitions and earn rewards for their work.
 
-#### - [Start an Opeator node](../farming-&-staking/staking/operators/register-operator)
+#### - [Start an Opeator node](/docs/farming-&-staking/staking/operators/register-operator.mdx)
 
 ### **Become a timekeeper**
 
 **Timekeepers** on the Subspace Network are responsible for running the **Proof-of-Time chain** and maintaining the randomness beacon for the **consensus chain**.
 
-#### - [Start timekeeping](../farming-&-staking/timekeeping)
+#### - [Start timekeeping](/docs/farming-&-staking/timekeeping.md)
 
 ## 📖 Develop on The Subspace Network
 ---
@@ -57,7 +57,7 @@ Farmers can nominate **operators** and back them with their tokens, increasing t
 
 The Subspace Network hosts an **EVM (Ethereum Virtual Machine)**, that allows you to deploy your **smart contracts.** 
 
-#### - [EVM Development](../develop/nova/intro)
+#### - [EVM Development](/docs/develop/nova/intro.md)
 
 ### Utilize the Core Protocol
 The Subspace Network aims to provide an amazing developer experience to anyone who wishes to build on top of the protocol. As such we have started working on a variety of tools to assist and promote development on our network. 

--- a/versioned_docs/version-latest/learn/intro.md
+++ b/versioned_docs/version-latest/learn/intro.md
@@ -29,8 +29,8 @@ The Subspace Network is an ambitious layer zero protocol which is the first scal
 
 Choose one of the following methods to **start farming** on the Network (from easy to more complex):
 
-#### - [Start Farming with Space Acres](../farming-&-staking/farming/space-acres/space-acres-install)
-#### - [Start Farming with Advanced CLI](../farming-&-staking/farming/advanced-cli/cli-install)
+#### - [Start Farming with Space Acres](/docs/farming-&-staking/farming/space-acres/space-acres-install.mdx)
+#### - [Start Farming with Advanced CLI](/docs/farming-&-staking/farming/advanced-cli/cli-install.mdx)
 
 ### **Become a nominator**
 


### PR DESCRIPTION
Attempt to fix: "Autonomys website CTA "Secure the network" -> Welcome page of the docs -> 404 for all links (farming with SA, CLI, Operator, etc). The link has an additional /learn/  in the middle of the URL, that's not replicable in other scenarios"