### PR TITLE
Improve operators guide, add section to download executables

### DIFF
--- a/docs/farming-&-staking/staking/operators/platforms/_linux.mdx
+++ b/docs/farming-&-staking/staking/operators/platforms/_linux.mdx
@@ -1,0 +1,38 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import CodeBlock from '@theme/CodeBlock';
+import Link from '@docusaurus/Link';
+import styles from '@site/src/pages/index.module.css';
+
+### Download the Advanced CLI Executables 
+---
+
+<div className={`${styles.buttons} ${styles.flexContainer}`}>
+  <Link
+    className="button button--secondary"
+    to="https://github.com/autonomys/subspace/releases/download/gemini-3h-2024-jul-29/subspace-node-ubuntu-x86_64-skylake-gemini-3h-2024-jul-29"
+    style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
+    <span style={{ fontSize: '20px' }}>Node Executable</span>
+    <span style={{ fontSize: '14px' }}>(Skylake+ CPU)</span>
+  </Link>
+</div>
+
+<div className={`${styles.buttons} ${styles.flexContainer}`}>
+  <Link
+    className="button button--secondary"
+    to="https://github.com/autonomys/subspace/releases/download/gemini-3h-2024-jul-29/subspace-node-ubuntu-x86_64-v2-gemini-3h-2024-jul-29"
+    style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
+    <span style={{ fontSize: '20px' }}>Node Executable</span>
+    <span style={{ fontSize: '14px' }}>(Legacy CPU)</span>
+  </Link>
+</div>
+
+<div className={`${styles.buttons} ${styles.flexContainer}`}>
+  <Link
+    className="button button--secondary"
+    to="https://github.com/autonomys/subspace/releases/download/gemini-3h-2024-jul-29/subspace-node-ubuntu-aarch64-gemini-3h-2024-jul-29"
+    style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
+    <span style={{ fontSize: '20px' }}>Node Executable</span>
+    <span style={{ fontSize: '14px' }}>(Aarch64/Raspberry Pi)</span>
+  </Link>
+</div>

--- a/docs/farming-&-staking/staking/operators/platforms/_macos.mdx
+++ b/docs/farming-&-staking/staking/operators/platforms/_macos.mdx
@@ -1,0 +1,15 @@
+import Link from '@docusaurus/Link';
+import styles from '@site/src/pages/index.module.css';
+
+### Download Advanced CLI Executables
+---
+ 
+<div className={`${styles.buttons} ${styles.flexContainer}`}>
+  <Link
+    className="button button--secondary"
+    to="https://github.com/autonomys/subspace/releases/download/gemini-3h-2024-jul-29/subspace-node-macos-aarch64-gemini-3h-2024-jul-29.zip"
+    style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
+    <span style={{ fontSize: '20px' }}>Node Executable</span>
+    <span style={{ fontSize: '14px' }}>(Apple CPU)</span>
+  </Link>
+</div>

--- a/docs/farming-&-staking/staking/operators/platforms/_windows.mdx
+++ b/docs/farming-&-staking/staking/operators/platforms/_windows.mdx
@@ -1,0 +1,26 @@
+import Link from '@docusaurus/Link';
+import styles from '@site/src/pages/index.module.css';
+
+ 
+### Download the Advanced CLI Executables 
+---
+
+<div className={`${styles.buttons} ${styles.flexContainer}`}>
+  <Link
+    className="button button--secondary"
+    to="https://github.com/autonomys/subspace/releases/download/gemini-3h-2024-jul-29/subspace-node-windows-x86_64-skylake-gemini-3h-2024-jul-29.exe"
+    style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
+    <span style={{ fontSize: '20px' }}>Node Executable</span>
+    <span style={{ fontSize: '14px' }}>(Skylake+ CPU)</span>
+  </Link>
+</div>
+ 
+<div className={`${styles.buttons} ${styles.flexContainer}`}>
+  <Link
+    className="button button--secondary"
+    to="https://github.com/autonomys/subspace/releases/download/gemini-3h-2024-jul-29/subspace-node-windows-x86_64-v2-gemini-3h-2024-jul-29.exe"
+    style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
+    <span style={{ fontSize: '20px' }}>Node Executable</span>
+    <span style={{ fontSize: '14px' }}>(Legacy CPU)</span>
+  </Link>
+</div>

--- a/docs/farming-&-staking/staking/operators/register-operator.mdx
+++ b/docs/farming-&-staking/staking/operators/register-operator.mdx
@@ -116,6 +116,7 @@ While it is possible to use `archive` for `blocks-pruning` and `state-pruning`, 
 --base-path NODE_DATA_PATH \`
 --blocks-pruning archive-canonical \`
 --state-pruning archive-canonical \`
+--sync full \`
 -- \`
 --domain-id your_domain_id \`
 --operator-id your_operator_id \`
@@ -133,6 +134,7 @@ While it is possible to use `archive` for `blocks-pruning` and `state-pruning`, 
 --base-path NODE_DATA_PATH \\
 --blocks-pruning archive-canonical \\
 --state-pruning archive-canonical \\
+--sync full \\
 -- \\
 --domain-id your_domain_id \\
 --operator-id your_operator_id \\
@@ -150,6 +152,7 @@ While it is possible to use `archive` for `blocks-pruning` and `state-pruning`, 
 --base-path NODE_DATA_PATH \\
 --blocks-pruning archive-canonical \\
 --state-pruning archive-canonical \\
+--sync full \\
 -- \\
 --domain-id your_domain_id \\
 --operator-id your_operator_id \\
@@ -188,7 +191,8 @@ While it is possible to use `archive` for `blocks-pruning` and `state-pruning`, 
       # Replace INSERT_YOUR_ID with your node ID (will be shown in telemetry)
       "--name", "INSERT_YOUR_ID",
       "--blocks-pruning", "archive-canonical",
-      "--state-pruning". "archive-canonical"
+      "--state-pruning", "archive-canonical", 
+      "--sync", "full", 
       "--",
       # Replace INSERT_YOUR_DOMAIN_ID with domain ID you want to be operator on
       "--domain-id", "INSERT_YOUR_DOMAIN_ID",

--- a/docs/farming-&-staking/staking/operators/register-operator.mdx
+++ b/docs/farming-&-staking/staking/operators/register-operator.mdx
@@ -14,10 +14,33 @@ import CodeBlock from '@theme/CodeBlock';
 import Link from '@docusaurus/Link';
 import styles from '@site/src/pages/index.module.css';
 
+import WindowsPage from '/docs/farming-&-staking/staking/operators/platforms/_windows.mdx';
+import MacOSPage from '/docs/farming-&-staking/staking/operators/platforms/_macos.mdx';
+import LinuxPage from '/docs/farming-&-staking/staking/operators/platforms/_linux.mdx';
 
-:::note
-Currently, the domain chain does not support syncing from other operator nodes; it needs to be deterministically derived from the consensus chain block by block.
+## Download Subspace Node
+
+Download `Subspace Node` for your respective operating system.
+
+:::tip
+For running the Operator Node on Linux, proceed directly to the next step. 
 :::
+
+<Tabs groupId="OS">
+
+<TabItem value="windows" label="🖼️ Windows" default>
+<WindowsPage />
+</TabItem>
+
+<TabItem value="macos" label="🍎macOS" default>
+<MacOSPage />
+</TabItem>
+
+<TabItem value="linux" label="🐧Ubuntu">
+<LinuxPage />
+</TabItem>
+
+</Tabs>
 
 ### Choosing the right domain
 
@@ -59,6 +82,11 @@ subspace-node [consensus-chain-args] -- [domain-args]
 
 Example:
 Start a node as operator on `gemini-3h` chain:
+
+
+:::note
+Currently, the domain chain does not support syncing from other operator nodes; it needs to be deterministically derived from the consensus chain block by block.
+:::
 
 :::info
 You need to **wipe** and sync your node from genesis block without using snap sync, since you need to sync both consensus and domain chains.

--- a/versioned_docs/version-latest/farming-&-staking/staking/operators/platforms/_linux.mdx
+++ b/versioned_docs/version-latest/farming-&-staking/staking/operators/platforms/_linux.mdx
@@ -1,0 +1,38 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import CodeBlock from '@theme/CodeBlock';
+import Link from '@docusaurus/Link';
+import styles from '@site/src/pages/index.module.css';
+
+### Download the Advanced CLI Executables 
+---
+
+<div className={`${styles.buttons} ${styles.flexContainer}`}>
+  <Link
+    className="button button--secondary"
+    to="https://github.com/autonomys/subspace/releases/download/gemini-3h-2024-jul-29/subspace-node-ubuntu-x86_64-skylake-gemini-3h-2024-jul-29"
+    style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
+    <span style={{ fontSize: '20px' }}>Node Executable</span>
+    <span style={{ fontSize: '14px' }}>(Skylake+ CPU)</span>
+  </Link>
+</div>
+
+<div className={`${styles.buttons} ${styles.flexContainer}`}>
+  <Link
+    className="button button--secondary"
+    to="https://github.com/autonomys/subspace/releases/download/gemini-3h-2024-jul-29/subspace-node-ubuntu-x86_64-v2-gemini-3h-2024-jul-29"
+    style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
+    <span style={{ fontSize: '20px' }}>Node Executable</span>
+    <span style={{ fontSize: '14px' }}>(Legacy CPU)</span>
+  </Link>
+</div>
+
+<div className={`${styles.buttons} ${styles.flexContainer}`}>
+  <Link
+    className="button button--secondary"
+    to="https://github.com/autonomys/subspace/releases/download/gemini-3h-2024-jul-29/subspace-node-ubuntu-aarch64-gemini-3h-2024-jul-29"
+    style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
+    <span style={{ fontSize: '20px' }}>Node Executable</span>
+    <span style={{ fontSize: '14px' }}>(Aarch64/Raspberry Pi)</span>
+  </Link>
+</div>

--- a/versioned_docs/version-latest/farming-&-staking/staking/operators/platforms/_macos.mdx
+++ b/versioned_docs/version-latest/farming-&-staking/staking/operators/platforms/_macos.mdx
@@ -1,0 +1,15 @@
+import Link from '@docusaurus/Link';
+import styles from '@site/src/pages/index.module.css';
+
+### Download Advanced CLI Executables
+---
+ 
+<div className={`${styles.buttons} ${styles.flexContainer}`}>
+  <Link
+    className="button button--secondary"
+    to="https://github.com/autonomys/subspace/releases/download/gemini-3h-2024-jul-29/subspace-node-macos-aarch64-gemini-3h-2024-jul-29.zip"
+    style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
+    <span style={{ fontSize: '20px' }}>Node Executable</span>
+    <span style={{ fontSize: '14px' }}>(Apple CPU)</span>
+  </Link>
+</div>

--- a/versioned_docs/version-latest/farming-&-staking/staking/operators/platforms/_windows.mdx
+++ b/versioned_docs/version-latest/farming-&-staking/staking/operators/platforms/_windows.mdx
@@ -1,0 +1,26 @@
+import Link from '@docusaurus/Link';
+import styles from '@site/src/pages/index.module.css';
+
+ 
+### Download the Advanced CLI Executables 
+---
+
+<div className={`${styles.buttons} ${styles.flexContainer}`}>
+  <Link
+    className="button button--secondary"
+    to="https://github.com/autonomys/subspace/releases/download/gemini-3h-2024-jul-29/subspace-node-windows-x86_64-skylake-gemini-3h-2024-jul-29.exe"
+    style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
+    <span style={{ fontSize: '20px' }}>Node Executable</span>
+    <span style={{ fontSize: '14px' }}>(Skylake+ CPU)</span>
+  </Link>
+</div>
+ 
+<div className={`${styles.buttons} ${styles.flexContainer}`}>
+  <Link
+    className="button button--secondary"
+    to="https://github.com/autonomys/subspace/releases/download/gemini-3h-2024-jul-29/subspace-node-windows-x86_64-v2-gemini-3h-2024-jul-29.exe"
+    style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
+    <span style={{ fontSize: '20px' }}>Node Executable</span>
+    <span style={{ fontSize: '14px' }}>(Legacy CPU)</span>
+  </Link>
+</div>

--- a/versioned_docs/version-latest/farming-&-staking/staking/operators/register-operator.mdx
+++ b/versioned_docs/version-latest/farming-&-staking/staking/operators/register-operator.mdx
@@ -116,6 +116,7 @@ While it is possible to use `archive` for `blocks-pruning` and `state-pruning`, 
 --base-path NODE_DATA_PATH \`
 --blocks-pruning archive-canonical \`
 --state-pruning archive-canonical \`
+--sync full \`
 -- \`
 --domain-id your_domain_id \`
 --operator-id your_operator_id \`
@@ -133,6 +134,7 @@ While it is possible to use `archive` for `blocks-pruning` and `state-pruning`, 
 --base-path NODE_DATA_PATH \\
 --blocks-pruning archive-canonical \\
 --state-pruning archive-canonical \\
+--sync full \\
 -- \\
 --domain-id your_domain_id \\
 --operator-id your_operator_id \\
@@ -150,6 +152,7 @@ While it is possible to use `archive` for `blocks-pruning` and `state-pruning`, 
 --base-path NODE_DATA_PATH \\
 --blocks-pruning archive-canonical \\
 --state-pruning archive-canonical \\
+--sync full \\
 -- \\
 --domain-id your_domain_id \\
 --operator-id your_operator_id \\
@@ -188,7 +191,8 @@ While it is possible to use `archive` for `blocks-pruning` and `state-pruning`, 
       # Replace INSERT_YOUR_ID with your node ID (will be shown in telemetry)
       "--name", "INSERT_YOUR_ID",
       "--blocks-pruning", "archive-canonical",
-      "--state-pruning". "archive-canonical"
+      "--state-pruning", "archive-canonical", 
+      "--sync", "full", 
       "--",
       # Replace INSERT_YOUR_DOMAIN_ID with domain ID you want to be operator on
       "--domain-id", "INSERT_YOUR_DOMAIN_ID",

--- a/versioned_docs/version-latest/farming-&-staking/staking/operators/register-operator.mdx
+++ b/versioned_docs/version-latest/farming-&-staking/staking/operators/register-operator.mdx
@@ -14,10 +14,33 @@ import CodeBlock from '@theme/CodeBlock';
 import Link from '@docusaurus/Link';
 import styles from '@site/src/pages/index.module.css';
 
+import WindowsPage from '/docs/farming-&-staking/staking/operators/platforms/_windows.mdx';
+import MacOSPage from '/docs/farming-&-staking/staking/operators/platforms/_macos.mdx';
+import LinuxPage from '/docs/farming-&-staking/staking/operators/platforms/_linux.mdx';
 
-:::note
-Currently, the domain chain does not support syncing from other operator nodes; it needs to be deterministically derived from the consensus chain block by block.
+## Download Subspace Node
+
+Download `Subspace Node` for your respective operating system.
+
+:::tip
+For running the Operator Node on Linux, proceed directly to the next step. 
 :::
+
+<Tabs groupId="OS">
+
+<TabItem value="windows" label="🖼️ Windows" default>
+<WindowsPage />
+</TabItem>
+
+<TabItem value="macos" label="🍎macOS" default>
+<MacOSPage />
+</TabItem>
+
+<TabItem value="linux" label="🐧Ubuntu">
+<LinuxPage />
+</TabItem>
+
+</Tabs>
 
 ### Choosing the right domain
 
@@ -59,6 +82,11 @@ subspace-node [consensus-chain-args] -- [domain-args]
 
 Example:
 Start a node as operator on `gemini-3h` chain:
+
+
+:::note
+Currently, the domain chain does not support syncing from other operator nodes; it needs to be deterministically derived from the consensus chain block by block.
+:::
 
 :::info
 You need to **wipe** and sync your node from genesis block without using snap sync, since you need to sync both consensus and domain chains.


### PR DESCRIPTION
This PR addresses the issue - Operators guide: "It is not clear that Advanced CLI should be downloaded first; needs a cross-link with the CLI installation page "


I originally though about re-using the "advanced-cli" section for farming, but it includes too much unrelated information, including downloading farmer executables. 