### PR TITLE
Update documentation domain

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -28,7 +28,7 @@ function getLocalizedConfigValue(/** @type {string} */ key) {
 const config = {
   title: getLocalizedConfigValue('title'),
   tagline: getLocalizedConfigValue('tagline'),
-  url: 'https://docs.subspace.network',
+  url: 'https://docs.autonomys.xyz',
   baseUrl: '/',
   onBrokenLinks: 'warn',
   onBrokenMarkdownLinks: 'warn',

--- a/versioned_docs/version-latest/participate/contribute.md
+++ b/versioned_docs/version-latest/participate/contribute.md
@@ -43,7 +43,7 @@ Please refer to our [Code of Conduct](CODE_OF_CONDUCT.md).
 Please follow this pathway for *minor* contributions such as spelling errors, typos, rewording, etc. 
 > If you are adding entirely new pages, features, etc, then please refer to the `Advanced` portion of this section.
 
-1. Go to [Autonomys Documentation](https://docs.subspace.network), and find the page that you would like to change.
+1. Go to [Autonomys Documentation](https://docs.autonomys.xyz), and find the page that you would like to change.
 2. Scroll to the bottom and click `Edit this page`.
 3. This will open up GitHub, and direct you to the raw page on GitHub.
 4. In the top right click the `pencil` emoji to edit the page.


### PR DESCRIPTION
Update domain from docs.subspace.network to docs.autonomys.xyz. This will be deployed in conjunction with DNS redirects to preserve historical links.