### PR TITLE
Update image host and fix admonitions formatting

### DIFF
--- a/docs/farming-&-staking/farming/space-acres/space-acres-install.mdx
+++ b/docs/farming-&-staking/farming/space-acres/space-acres-install.mdx
@@ -133,13 +133,13 @@ For your convenience, we've provided a table detailing the color codes associate
 
 | Status            | Color Preview | Description                          |
 |-------------------|---------------|--------------------------------------|
-| Default           | ![#727272](https://via.placeholder.com/15/727272/000000?text=+) #727272 | Default state of a farm sector       |
-| Plotted           | ![#9fc4ff](https://via.placeholder.com/15/9fc4ff/000000?text=+) #9fc4ff | Sector is plotted                    |
-| About to Expire   | ![#ffd678](https://via.placeholder.com/15/ffd678/000000?text=+) #ffd678 | Sector is nearing expiration         |
-| Expired           | ![#ff877c](https://via.placeholder.com/15/ff877c/000000?text=+) #ff877c | Sector has expired                   |
-| Downloading       | ![#499249](https://via.placeholder.com/15/499249/000000?text=+) #499249 | Sector is in the process of downloading (animated) |
-| Encoding          | ![#ff5365](https://via.placeholder.com/15/ff5365/000000?text=+) #ff5365 | Sector is encoding data (animated)   |
-| Writing           | ![#9fc4ff](https://via.placeholder.com/15/9fc4ff/000000?text=+) #9fc4ff | Sector is writing data (animated)    |
+| Default           | ![#727272](https://dummyimage.com/15/727272/000000&text=+) #727272 | Default state of a farm sector       |
+| Plotted           | ![#9fc4ff](https://dummyimage.com/15/9fc4ff/000000&text=+) #9fc4ff | Sector is plotted                    |
+| About to Expire   | ![#ffd678](https://dummyimage.com/15/ffd678/000000&text=+) #ffd678 | Sector is nearing expiration         |
+| Expired           | ![#ff877c](https://dummyimage.com/15/ff877c/000000&text=+) #ff877c | Sector has expired                   |
+| Downloading       | ![#499249](https://dummyimage.com/15/499249/000000&text=+) #499249 | Sector is in the process of downloading (animated) |
+| Encoding          | ![#ff5365](https://dummyimage.com/15/ff5365/000000&text=+) #ff5365 | Sector is encoding data (animated)   |
+| Writing           | ![#9fc4ff](https://dummyimage.com/15/9fc4ff/000000&text=+) #9fc4ff | Sector is writing data (animated)    |
 
 
 
@@ -148,6 +148,7 @@ To learn more about the syncing, plotting, and farming processes on the Autonomy
 - [Synchronization](https://academy.autonomys.xyz/subspace-protocol/network-architecture/networking-protocols#synchronization)
 - [Plotting](https://academy.autonomys.xyz/subspace-protocol/consensus/proof-of-archival-storage/plotting)
 - [Farming](https://academy.autonomys.xyz/subspace-protocol/consensus/proof-of-archival-storage/farming)
+
 :::
 
 


### PR DESCRIPTION
placeholder.com was added to several DNS blacklists after being acquired by a warehouse rental company a few years ago. This has now been updated to dummyimage.com.

Additionally, the formatting for the "Learn More" note under the admonitions section has been fixed.