### PR TITLE
Standardized Astral naming to Astral Explorer

### DIFF
--- a/docs/develop/nova/block_explorer.md
+++ b/docs/develop/nova/block_explorer.md
@@ -1,5 +1,5 @@
 ---
-title: Astral Block Explorer
+title: Nova Block Explorer
 sidebar_position: 10
 description: Autonomys hosted block explorer
 keywords:

--- a/docs/develop/nova/block_explorer.md
+++ b/docs/develop/nova/block_explorer.md
@@ -1,15 +1,15 @@
 ---
-title: Autonomys block explorer
+title: Astral Block Explorer
 sidebar_position: 10
 description: Autonomys hosted block explorer
 keywords:
-  - block explorer Nova EVM domain
-  - autonomys network
+  - EVM Domain Nova
+  - Autonomys Network
 ---
 
-### Autonomys Nova Block Explorer
+### EVM Domain Nova Block Explorer
 
-**[Block explorer link](https://nova.subspace.network)**
+**[Nova Block Explorer](https://nova.subspace.network)**
 
 This early version provides a clear and user-friendly visualization of Autonomys-specific statistics that cater to the needs of our farmers and developers.
 

--- a/docs/develop/nova/remix_guide.md
+++ b/docs/develop/nova/remix_guide.md
@@ -13,7 +13,7 @@ Remix is a great tool that allows you to easily write, test and deploy smart con
 
 Remix has [amazing documentation](https://remix-ide.readthedocs.io/en/latest/), but this guide will cover everything required to get you started.
 
-1. Using the browser of your choice navigate to **[Remix website.](https://remix.ethereum.org)**
+1. Using the browser of your choice navigate to **[Remix website](https://remix.ethereum.org)**.
 You will see a file explorer and interface for creating new workspaces, integrations with GitHub, Gist, IPFS, HTTPS, preloaded templates, and plugins.
 Let’s create a new workspace by clicking on the + sign beside WORKSPACES.
 

--- a/docs/farming-&-staking/farming/additional-guides/verify-farmer.md
+++ b/docs/farming-&-staking/farming/additional-guides/verify-farmer.md
@@ -11,13 +11,13 @@ keywords:
 ---
 
 We are thrilled to announce the **Verified Farmer** role on our [Discord server](https://autonomys.xyz/discord)!
-You can track your farmer through the [Astral Block Explorer.](https://astral.autonomys.xyz)
+You can track your farmer through the [Astral Block Explorer](https://astral.autonomys.xyz).
 
 ## Eligibility for the Verified Farmer Role
 
 **If you have earned a block or vote reward**, you can now link your Discord account to your farmer wallet through the [Astral](https://astral.autonomys.xyz) to obtain this role. Here’s how to do it:
 
-1. Select **Connect Wallet** in the top right corner of the [Astral Block Explorer.](https://astral.autonomys.xyz)
+1. Select **Connect Wallet** in the top right corner of the [Astral Block Explorer](https://astral.autonomys.xyz).
     
     ![Connect Wallet](/img/doc-imgs/verify-farmer/connect-wallet.png)
 

--- a/docs/farming-&-staking/farming/advanced-cli/cli-tips.mdx
+++ b/docs/farming-&-staking/farming/advanced-cli/cli-tips.mdx
@@ -15,13 +15,13 @@ keywords:
 
 Welcome to the Additional Tips section! Whether you're a seasoned farmer or just starting out with the Autonomys Network, these tips and tricks are designed to enhance your experience and efficiency. Here, we delve into practical advice and lesser-known techniques to help you fine-tune your farming setup and navigate common challenges with ease. From configuring your environment to managing background processes, these insights are tailored to ensure your Farmer operates smoothly and effectively. Let's dive in and explore how you can get the most out of your Autonomys Network Farmer.
 
-### Telemetry & Block Explorer
+### Telemetry & Astral Block Explorer
 
 Explore the Autonomys Network in depth with our variety of telemetry tools and block explorers. Whether you're monitoring network activity or exploring blockchain data, these resources provide comprehensive insights into the network's performance and transactions.
 
 - **[Telemetry Server](https://telemetry.subspace.network)**: Get real-time insights into network activity and performance metrics. Ideal for monitoring the overall health and status of the Autonomys Network.
 
-- **[Official Block Explorer](https://astral.autonomys.xyz)**: Our primary tool for viewing blocks, transactions, and network activity on the Autonomys Network. This explorer offers an intuitive interface and detailed information.
+- **[Astral Block Explorer](https://astral.autonomys.xyz)**: Our primary tool for viewing blocks, transactions, and network activity on the Autonomys Network. This explorer offers an intuitive interface and detailed information.
 
 - **[Subscan Block Explorer](https://subspace.subscan.io)**: An alternative block explorer providing detailed views of blocks, transactions, and network events. Subscan is known for its user-friendly interface and additional data analytics features.
 

--- a/docs/farming-&-staking/wallets/polkadot.md
+++ b/docs/farming-&-staking/wallets/polkadot.md
@@ -1,7 +1,7 @@
 ---
 title: Polkadot.js
 sidebar_position: 2
-description: How to configure the Polkadot Substrate wallet for the Subspace Network
+description: How to configure the Polkadot Substrate wallet for the Autonomys Network
 keywords:
     - Farmer
     - Farming
@@ -74,7 +74,7 @@ Some users may be provided an existing mnemonic seed phrase that may have been p
 
 ## Troubleshooting
 
-If you face any trouble or would like to learn about other features for Polkadot.js, please see the [Official Polkadot.js Documentation.](https://polkadot.js.org/) We have included some basic FAQ's below.
+If you face any trouble or would like to learn about other features for Polkadot.js, please see the [Official Polkadot.js Documentation](https://polkadot.js.org/). We have included some basic FAQ's below.
 
 ### How can I find my Public Address?
 - You can see your default substrate public address right below your Wallet name inside the extension

--- a/docs/farming-&-staking/wallets/polkadot.md
+++ b/docs/farming-&-staking/wallets/polkadot.md
@@ -1,7 +1,7 @@
 ---
 title: Polkadot.js
 sidebar_position: 2
-description: How to configure the Polkadot Substrate wallet for the Autonomys Network
+description: How to configure the Polkadot Substrate wallet for the Subspace Network
 keywords:
     - Farmer
     - Farming

--- a/docs/farming-&-staking/wallets/subwallet.md
+++ b/docs/farming-&-staking/wallets/subwallet.md
@@ -1,7 +1,7 @@
 ---
 title: SubWallet (Recommended)
 sidebar_position: 1
-description: How to configure the SubWallet Substrate wallet for the Autonomys Network
+description: How to configure the SubWallet Substrate wallet for the Subspace Network
 keywords:
     - Farmer
     - Farming

--- a/docs/farming-&-staking/wallets/subwallet.md
+++ b/docs/farming-&-staking/wallets/subwallet.md
@@ -1,7 +1,7 @@
 ---
 title: SubWallet (Recommended)
 sidebar_position: 1
-description: How to configure the SubWallet Substrate wallet for the Subspace Network
+description: How to configure the SubWallet Substrate wallet for the Autonomys Network
 keywords:
     - Farmer
     - Farming
@@ -94,7 +94,7 @@ This also can be helpful for in-development networks such as the Subspace Networ
 - Symbol
 - Block explorer
 - Crowdloan URL
-The only option that is required is the Provider URL. You can add an explorer if you would like but it is not required. The current Subspace Explorer is available [here](https://astral.autonomys.xyz).
+The only required option is the Provider URL. Adding an explorer is optional. You can access the current [Astral Block Explorer](https://astral.autonomys.xyz).
 You can refer to the *RPC Endpoints* above for available provider URLs for the Subspace Network.
     
 5. Fill in the provider URL, once you click out of this box it will check the URL and add the rest of the information, then click Save. 
@@ -108,7 +108,7 @@ You can refer to the *RPC Endpoints* above for available provider URLs for the S
 
 ## Troubleshooting
 
-If you face any trouble or would like to learn about other features for SubWallet, please see the [Official SubWallet Documentation.](https://docs.subwallet.app/).
+If you face any trouble or would like to learn about other features for SubWallet, please see the [Official SubWallet Documentation](https://docs.subwallet.app/).
 
 
 ### How do I backup my wallet?

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -210,7 +210,7 @@ const config = {
                 href: 'https://telemetry.subspace.network',
               },
               {
-                label: 'Autonomys Explorer',
+                label: 'Astral Block Explorer',
                 href: 'https://astral.autonomys.xyz',
               },
               {
@@ -274,7 +274,7 @@ const config = {
                 href: 'https://github.com/autonomys/space-acres'
               },
               {
-                label: 'Astral Autonomys Explorer',
+                label: 'Astral Block Explorer',
                 href: 'https://astral.autonomys.xyz'
               }
             ],


### PR DESCRIPTION
Standardized naming convention for Astral across documentation. 

Updated all instances to use 'Astral Explorer' as per preferred naming convention.