### PR TITLE
Remove community telegram and discord links

### DIFF
--- a/docs/participate/index.md
+++ b/docs/participate/index.md
@@ -15,26 +15,6 @@ Please note, all community provided resources are **non-official**. For clarific
 
 :::
 
-## Community Groups
----
-
-
-
-### Telegram
-
-🇹🇷 - [türk telegram topluluğu](https://t.me/subspacenetworkturkey)
-
-### Discord
-
-🇨🇳 - [中国不和谐社区](https://discord.com/channels/864285291518361610/940656159927451668)
-
-🇰🇷 - [한국 커뮤니티](https://discord.com/channels/864285291518361610/941490199786037278)
-
-🇷🇺 - [русское дискорд-сообщество](https://discord.com/channels/864285291518361610/940699533640368128)
-
-🇺🇦 - [українська діскорд-спільнота](https://discord.com/channels/864285291518361610/940699198330925106)
-
-
 ## Community Translations
 ---
 ### Whitepaper


### PR DESCRIPTION
- Removed the community Telegram and Discord links in favor of the official ones as covered in #313.