### PR TITLE
Add available parameters admonition

### DIFF
--- a/docs/farming-&-staking/farming/advanced-cli/cli-install.mdx
+++ b/docs/farming-&-staking/farming/advanced-cli/cli-install.mdx
@@ -19,13 +19,19 @@ import SourcePage from './platforms/_source.mdx';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-:::tip Multiple Versions Available
+:::info Multiple Versions Available
 We offer several versions of our releases to accommodate different CPU architectures:
 
 - **Skylake:** Optimized for Intel Skylake and newer CPUs, as well as AMD Ryzen processors. Ideal for PCs manufactured from 2015 onward.
 - **Legacy (x86-64-v2):** Designed for Intel Broadwell, Haswell, and older CPUs, along with their AMD counterparts. Suitable for systems built between 2009 and 2015 and for virtual environments that do not support Skylake instructions.
 
 For the latest binaries and source code, please visit the **Releases** section on our [GitHub](https://github.com/autonomys/subspace/releases).
+:::
+
+:::tip Available Parameters
+
+A complete list of parameters and their functions can be obtained using the `--help` option with both `subspace-node` and `subspace-farmer`.
+
 :::
 
 ## Advanced CLI Installation Guide


### PR DESCRIPTION
- Included a section in the documentation detailing how to obtain a complete list of parameters and their functions using the `--help` option with `subspace-node` and `subspace-farmer`. This addresses issue #163.