### PR TITLE
Add email address to code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -61,7 +61,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-[INSERT CONTACT METHOD].
+<ecosystem@autonomys.xyz>.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -61,7 +61,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-<ecosystem@autonomys.xyz>.
+<a href="mailto:ecosystem@autonomys.xyz">ecosystem@autonomys.xyz</a>.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/docs/participate/CODE_OF_CONDUCT.md
+++ b/docs/participate/CODE_OF_CONDUCT.md
@@ -73,7 +73,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-<ecosystem@autonomys.xyz>.
+<a href="mailto:ecosystem@autonomys.xyz">ecosystem@autonomys.xyz</a>.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/docs/participate/CODE_OF_CONDUCT.md
+++ b/docs/participate/CODE_OF_CONDUCT.md
@@ -73,7 +73,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-[INSERT CONTACT METHOD].
+<ecosystem@autonomys.xyz>.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the


### PR DESCRIPTION
Add email address to code of conduct to replace the placeholder.