### PR TITLE
Auto-collapse sidebar categories

### DIFF
--- a/docs/learn/_category_.json
+++ b/docs/learn/_category_.json
@@ -1,8 +1,5 @@
 {
     "label": "Learn",
     "position": 1,
-    "link": {
-      "type": "generated-index",
-      "description": "Learn about the Autonomys Network"
-    }
+    "link": null
 }

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -56,7 +56,7 @@ const config = {
           // Redirecting to the new root URL (/) as the previous root (/docs) is no longer in use.
 
           // Learn
-          { to: '/learn/intro', from: ['/docs/learn/intro'] },
+          { to: '/learn/intro', from: ['/category/learn,', '/docs/learn/intro'] },
           { to: '/learn/security', from: ['/docs/learn/security'] },
           { to: '/learn/academy', from: ['/docs/learn/academy'] },
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -177,6 +177,11 @@ const config = {
       colorMode:{
         defaultMode: 'dark'
       },
+      docs: {
+        sidebar: {
+          autoCollapseCategories: true,
+        },
+      },
       navbar: {
         title: 'Autonomys',
         logo: {


### PR DESCRIPTION
This will collapse all sibling categories when expanding another category. This saves the user from having too many categories open and helps them focus on the selected section.

This addresses what was seen here:

_Originally posted by @randywessels in https://github.com/autonomys/subspace-docs/pull/676#pullrequestreview-2353173252_