### PR TITLE
Llvm clang16 removal

### DIFF
--- a/docs/farming-&-staking/farming/advanced-cli/platforms/_source.mdx
+++ b/docs/farming-&-staking/farming/advanced-cli/platforms/_source.mdx
@@ -19,10 +19,6 @@ You'll have to have [Rust toolchain](https://rustup.rs/) installed as well as LL
 sudo apt-get install llvm clang cmake
 ```
 
-:::warning LLVM + Clang 16
-The build with LLVM + Clang 16 ends with `UnknownOpcode(192)` error due to breaking changes concerning WASM in LLVM 16. You can read more about this issue [here](https://github.com/paritytech/substrate/issues/13636). At this point, the solution is to use LLVM + Clang 15 and add the `-Z build-std` flag to the `cargo build` command. 
-:::
-
 Now clone the source and build snapshot `snapshot-2023-aug-18` (replace occurrences with the snapshot you want to build):
 ```shell-session
 git clone https://github.com/autonomys/subspace.git

--- a/docs/farming-&-staking/farming/advanced-cli/platforms/_source.mdx
+++ b/docs/farming-&-staking/farming/advanced-cli/platforms/_source.mdx
@@ -19,11 +19,11 @@ You'll have to have [Rust toolchain](https://rustup.rs/) installed as well as LL
 sudo apt-get install llvm clang cmake
 ```
 
-Now clone the source and build snapshot `snapshot-2023-aug-18` (replace occurrences with the snapshot you want to build):
+Now clone the source and build snapshot `mainnet-2024-nov-13-2` (replace occurrences with the snapshot you want to build):
 ```shell-session
 git clone https://github.com/autonomys/subspace.git
 cd subspace
-git checkout snapshot-2023-aug-18
+git checkout mainnet-2024-nov-13-2
 cargo build \
     --profile production \
     --bin subspace-node \


### PR DESCRIPTION
Remove the warning about LLVM + Clang 16 from Build from Source under Advanced CLI farming as it is is no longer relevant.