### PR TITLE
Fix subscan link that was using the old subdomain

### DIFF
--- a/docs/farming-&-staking/farming/advanced-cli/cli-tips.mdx
+++ b/docs/farming-&-staking/farming/advanced-cli/cli-tips.mdx
@@ -26,7 +26,7 @@ Explore the Autonomys Network in depth with our variety of telemetry tools and b
 
 - **[Astral Block Explorer](https://astral.autonomys.xyz)**: Our primary tool for viewing blocks, transactions, and network activity on the Autonomys Network. This explorer offers an intuitive interface and detailed information.
 
-- **[Subscan Block Explorer](https://subspace.subscan.io)**: An alternative block explorer providing detailed views of blocks, transactions, and network events. Subscan is known for its user-friendly interface and additional data analytics features.
+- **[Subscan Block Explorer](https://autonomys.https://autonomys.subscan.io/)**: An alternative block explorer providing detailed views of blocks, transactions, and network events. Subscan is known for its user-friendly interface and additional data analytics features.
 
 - **[Polkadot.js Block Explorer](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc.mainnet.subspace.foundation%2Fws#/explorer)**: For users familiar with the Polkadot ecosystem, this explorer offers a seamless experience for exploring the Autonomys Network using the Polkadot.js interface.
 

--- a/docs/farming-&-staking/farming/advanced-cli/cli-tips.mdx
+++ b/docs/farming-&-staking/farming/advanced-cli/cli-tips.mdx
@@ -26,7 +26,7 @@ Explore the Autonomys Network in depth with our variety of telemetry tools and b
 
 - **[Astral Block Explorer](https://astral.autonomys.xyz)**: Our primary tool for viewing blocks, transactions, and network activity on the Autonomys Network. This explorer offers an intuitive interface and detailed information.
 
-- **[Subscan Block Explorer](https://autonomys.https://autonomys.subscan.io/)**: An alternative block explorer providing detailed views of blocks, transactions, and network events. Subscan is known for its user-friendly interface and additional data analytics features.
+- **[Subscan Block Explorer](https://autonomys.subscan.io/)**: An alternative block explorer providing detailed views of blocks, transactions, and network events. Subscan is known for its user-friendly interface and additional data analytics features.
 
 - **[Polkadot.js Block Explorer](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc.mainnet.subspace.foundation%2Fws#/explorer)**: For users familiar with the Polkadot ecosystem, this explorer offers a seamless experience for exploring the Autonomys Network using the Polkadot.js interface.
 

--- a/docs/farming-&-staking/staking/staking.md
+++ b/docs/farming-&-staking/staking/staking.md
@@ -57,7 +57,7 @@ Three important factors to pay attention to are `Nominator Tax`, `Min. Stake`, a
 
 ### Check if your **nomination** worked successfully
 
-1. Navigate to **[Autonomys Subscan](https://subspace.subscan.io/)** portal.
+1. Navigate to **[Autonomys Subscan](https://autonomys.subscan.io/)** portal.
 2. Click on `Blockchain` -> `Extrinsics`.
 
   ![Staking-9](/img/doc-imgs/operators-staking/Staking-9.png)


### PR DESCRIPTION
Changed from https://subspace.subscan.io to https://autonomys.subscan.io