### PR TITLE
Temporarily remove Chinese translations

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -44,7 +44,7 @@ const config = {
   // to replace "en" with "zh-Hans".
   i18n: {
     defaultLocale,
-    locales: ["de", "en", "fr", "id", "it", "ja", "uk", "zh", "pt", "ru", "vi", "es", "tr"],
+    locales: ["de", "en", "fr", "id", "it", "ja", "uk", "pt", "ru", "vi", "es", "tr"],
   },
   
   markdown: {


### PR DESCRIPTION
Temporarily remove Chinese translations while we work on a CrowdIn issue.