### PR TITLE
Add -C 16384 -O bigalloc to ext4 formatting for improved SSD performance

### DIFF
--- a/docs/farming-&-staking/farming/intro.mdx
+++ b/docs/farming-&-staking/farming/intro.mdx
@@ -110,8 +110,8 @@ Linux systems may have a default file descriptor limit, which can vary based on 
 
 <TabItem value="ext4" label="☑️ ext4" default>
 This file system maximizes usable space for the farmer.
-```bash title="Recommended Formatting Command for Drives Dedicated to Subspace Plots:"
-sudo mkfs.ext4 -m 0 -T largefile4 /dev/sdX
+```bash title="Recommended Formatting Command for Drives Dedicated to Subspace Farms:"
+sudo mkfs.ext4 -m 0 -T largefile4 -C 16384 -O bigalloc /dev/sdX
 ```
 </TabItem>
 


### PR DESCRIPTION
Updated ext4 formatting options to include `-C 16384` and `-O bigalloc`.  
Using a block size of 16384, aligned with the native page size of most modern SSDs, enhances performance and reduces write amplification.  

This should close #770
