### PR TITLE
docs: minor typo fix academy.mdx

### DIFF
--- a/docs/learn/academy.mdx
+++ b/docs/learn/academy.mdx
@@ -11,7 +11,7 @@ keywords:
 
 import Link from '@docusaurus/Link';
 
-# Discover the Autonomys' protocol - Subspace Protocol
+# Discover the Autonomys protocol - Subspace Protocol
 
 Unlock the capabilities of Autonomys Network, a cutting-edge blockchain that perfectly balances scalability, security, and decentralization. With its innovative storage-based consensus mechanism and a commitment to core principles, Autonomys stands as a beacon of a scalable and secure decentralized future.
 


### PR DESCRIPTION
"Autonomys' protocol" -> "Autonomys Protocol"

There's no need to use an apostrophe.