### PR TITLE
Update mainnet-2025-jan-03 -> mainnet-2025-jan-14

### DIFF
--- a/docs/farming-&-staking/farming/advanced-cli/platforms/_linux.mdx
+++ b/docs/farming-&-staking/farming/advanced-cli/platforms/_linux.mdx
@@ -10,14 +10,14 @@ import styles from '@site/src/pages/index.module.css';
 <div className={`${styles.buttons} ${styles.flexContainer}`}>
   <Link
     className="button button--secondary"
-    to="https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-03/subspace-node-ubuntu-x86_64-skylake-mainnet-2025-jan-03"
+    to="https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-14/subspace-node-ubuntu-x86_64-skylake-mainnet-2025-jan-14"
     style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
     <span style={{ fontSize: '20px' }}>Node Executable</span>
     <span style={{ fontSize: '14px' }}>(Skylake+ CPU)</span>
   </Link>
   <Link
     className="button button--secondary"
-    to="https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-03/subspace-farmer-ubuntu-x86_64-skylake-mainnet-2025-jan-03"
+    to="https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-14/subspace-farmer-ubuntu-x86_64-skylake-mainnet-2025-jan-14"
     style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
     <span style={{ fontSize: '20px' }}>Farmer Executable</span>
     <span style={{ fontSize: '14px' }}>(Skylake+ CPU)</span>
@@ -27,14 +27,14 @@ import styles from '@site/src/pages/index.module.css';
 <div className={`${styles.buttons} ${styles.flexContainer}`}>
   <Link
     className="button button--secondary"
-    to="https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-03/subspace-node-ubuntu-x86_64-v2-mainnet-2025-jan-03"
+    to="https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-14/subspace-node-ubuntu-x86_64-v2-mainnet-2025-jan-14"
     style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
     <span style={{ fontSize: '20px' }}>Node Executable</span>
     <span style={{ fontSize: '14px' }}>(Legacy CPU)</span>
   </Link>
   <Link
     className="button button--secondary"
-    to="https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-03/subspace-farmer-ubuntu-x86_64-v2-mainnet-2025-jan-03"
+    to="https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-14/subspace-farmer-ubuntu-x86_64-v2-mainnet-2025-jan-14"
     style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
     <span style={{ fontSize: '20px' }}>Farmer Executable</span>
     <span style={{ fontSize: '14px' }}>(Legacy CPU)</span>
@@ -44,14 +44,14 @@ import styles from '@site/src/pages/index.module.css';
 <div className={`${styles.buttons} ${styles.flexContainer}`}>
   <Link
     className="button button--secondary"
-    to="https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-03/subspace-node-ubuntu-aarch64-mainnet-2025-jan-03"
+    to="https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-14/subspace-node-ubuntu-aarch64-mainnet-2025-jan-14"
     style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
     <span style={{ fontSize: '20px' }}>Node Executable</span>
     <span style={{ fontSize: '14px' }}>(Aarch64/Raspberry Pi)</span>
   </Link>
   <Link
     className="button button--secondary"
-    to="https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-03/subspace-farmer-ubuntu-aarch64-mainnet-2025-jan-03"
+    to="https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-14/subspace-farmer-ubuntu-aarch64-mainnet-2025-jan-14"
     style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
     <span style={{ fontSize: '20px' }}>Farmer Executable</span>
     <span style={{ fontSize: '14px' }}>(Aarch64/Raspberry Pi)</span>
@@ -68,14 +68,14 @@ import styles from '@site/src/pages/index.module.css';
 
 2. Make the `farmer` and `node` executable:
     ```bash
-    chmod +x subspace-farmer-ubuntu-x86_64-skylake-mainnet-2025-jan-03
-    chmod +x subspace-node-ubuntu-x86_64-skylake-mainnet-2025-jan-03
+    chmod +x subspace-farmer-ubuntu-x86_64-skylake-mainnet-2025-jan-14
+    chmod +x subspace-node-ubuntu-x86_64-skylake-mainnet-2025-jan-14
     ```
 
 3. Start the node using the command below. Replace `<NODE_DATA_PATH>` with the path where you want to store the node database and `<YOUR_NODE_NAME>` with a nickname of your choice. Ensure you copy the entire command:
 
     ```bash
-    ./subspace-node-ubuntu-x86_64-skylake-mainnet-2025-jan-03 \
+    ./subspace-node-ubuntu-x86_64-skylake-mainnet-2025-jan-14 \
       run \
       --chain mainnet \
       --base-path "<NODE_DATA_PATH>" \
@@ -136,7 +136,7 @@ If you choose to use the same drive for plots and the node database, make sure t
     # Replace <PATH_TO_FARM> with the directory where you want to store the plot
     # Replace <PLOT_SIZE> with the size of the plot (e.g. 10GB, 2TiB)
 
-    ./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2025-jan-03 farm \
+    ./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2025-jan-14 farm \
       --reward-address <WALLET_ADDRESS> \
       path=<PATH_TO_FARM>,size=<PLOT_SIZE>
     ```

--- a/docs/farming-&-staking/farming/advanced-cli/platforms/_macos.mdx
+++ b/docs/farming-&-staking/farming/advanced-cli/platforms/_macos.mdx
@@ -14,14 +14,14 @@ import styles from '@site/src/pages/index.module.css';
 <div className={`${styles.buttons} ${styles.flexContainer}`}>
   <Link
     className="button button--secondary"
-    to="https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-03/subspace-node-macos-aarch64-mainnet-2025-jan-03.zip"
+    to="https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-14/subspace-node-macos-aarch64-mainnet-2025-jan-14.zip"
     style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
     <span style={{ fontSize: '20px' }}>Node Executable</span>
     <span style={{ fontSize: '14px' }}>(Apple CPU)</span>
   </Link>
   <Link
     className="button button--secondary"
-    to="https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-03/subspace-farmer-macos-aarch64-mainnet-2025-jan-03.zip"
+    to="https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-14/subspace-farmer-macos-aarch64-mainnet-2025-jan-14.zip"
     style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
     <span style={{ fontSize: '20px' }}>Farmer Executable</span>
     <span style={{ fontSize: '14px' }}>(Apple CPU)</span>
@@ -39,14 +39,14 @@ After this, simply repeat the step you prompted for (step 4 or 6). This time, cl
 
 1. Open your favorite terminal, and change to the Downloads directory using `cd Downloads`
 2. Make the farmer & node executable:
-- `chmod +x subspace-farmer-macos-aarch64-mainnet-2025-jan-03`
-- `chmod +x subspace-node-macos-aarch64-mainnet-2025-jan-03`
+- `chmod +x subspace-farmer-macos-aarch64-mainnet-2025-jan-14`
+- `chmod +x subspace-node-macos-aarch64-mainnet-2025-jan-14`
 3. We will then start the node using the following command
 
 ```bash
 # Replace `INSERT_YOUR_ID` with a nickname you choose
 # Copy all of the lines below, they are all part of the same command
-./subspace-node-macos-aarch64-mainnet-2025-jan-03 \
+./subspace-node-macos-aarch64-mainnet-2025-jan-14 \
   run \
   --chain mainnet \
   --base-path NODE_DATA_PATH \
@@ -90,7 +90,7 @@ Using **run**, setting **--base-path** and specifying **--chain** is mandatory.
 # Replace `PATH_TO_FARM` with location where you want you store plot files
 # Replace `WALLET_ADDRESS` below with your account address from Polkadot.js wallet
 # Replace `PLOT_SIZE` with plot size in gigabytes or terabytes, for example 100G or 2T (but leave at least 60G of disk space for node and some for OS)
-./subspace-farmer-macos-aarch64-mainnet-2025-jan-03 farm --reward-address WALLET_ADDRESS path=PATH_TO_FARM,size=PLOT_SIZE
+./subspace-farmer-macos-aarch64-mainnet-2025-jan-14 farm --reward-address WALLET_ADDRESS path=PATH_TO_FARM,size=PLOT_SIZE
 ```
 
 2. You should see something similar in the terminal:

--- a/docs/farming-&-staking/farming/advanced-cli/platforms/_source.mdx
+++ b/docs/farming-&-staking/farming/advanced-cli/platforms/_source.mdx
@@ -19,11 +19,11 @@ You'll have to have [Rust toolchain](https://rustup.rs/) installed as well as LL
 sudo apt-get install llvm clang cmake
 ```
 
-Now clone the source and build snapshot `mainnet-2025-jan-03` (replace occurrences with the snapshot you want to build):
+Now clone the source and build snapshot `mainnet-2025-jan-14` (replace occurrences with the snapshot you want to build):
 ```shell-session
 git clone https://github.com/autonomys/subspace.git
 cd subspace
-git checkout mainnet-2025-jan-03
+git checkout mainnet-2025-jan-14
 cargo build \
     --profile production \
     --bin subspace-node \

--- a/docs/farming-&-staking/farming/advanced-cli/platforms/_systemd.mdx
+++ b/docs/farming-&-staking/farming/advanced-cli/platforms/_systemd.mdx
@@ -42,11 +42,11 @@ Download the Executable Files, using the appropriate commands:
         </summary>
 		Node:
 		<CodeBlock language="shell-session">
-		{`wget -O ~/.local/bin/subspace-node https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-03/subspace-node-ubuntu-x86_64-v2-mainnet-2025-jan-03`}
+		{`wget -O ~/.local/bin/subspace-node https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-14/subspace-node-ubuntu-x86_64-v2-mainnet-2025-jan-14`}
 		</CodeBlock>
 		Farmer:
 		<CodeBlock language="shell-session">
-		{`wget -O ~/.local/bin/subspace-farmer https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-03/subspace-farmer-ubuntu-x86_64-v2-mainnet-2025-jan-03`}
+		{`wget -O ~/.local/bin/subspace-farmer https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-14/subspace-farmer-ubuntu-x86_64-v2-mainnet-2025-jan-14`}
 		</CodeBlock>
     </details>
     <details>
@@ -55,11 +55,11 @@ Download the Executable Files, using the appropriate commands:
         </summary>
 		Node:
 		<CodeBlock language="shell-session">
-		{`wget -O ~/.local/bin/subspace-node https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-03/subspace-node-ubuntu-x86_64-skylake-mainnet-2025-jan-03`}
+		{`wget -O ~/.local/bin/subspace-node https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-14/subspace-node-ubuntu-x86_64-skylake-mainnet-2025-jan-14`}
 		</CodeBlock>
 		Farmer:
 		<CodeBlock language="shell-session">
-		{`wget -O ~/.local/bin/subspace-farmer https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-03/subspace-farmer-ubuntu-x86_64-skylake-mainnet-2025-jan-03`}
+		{`wget -O ~/.local/bin/subspace-farmer https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-14/subspace-farmer-ubuntu-x86_64-skylake-mainnet-2025-jan-14`}
 		</CodeBlock>
     </details>
 </details>
@@ -70,11 +70,11 @@ Download the Executable Files, using the appropriate commands:
     </summary>
 	Node:
 	<CodeBlock language="shell-session">
-	{`wget -O ~/.local/bin/subspace-node https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-03/subspace-node-ubuntu-aarch64-mainnet-2025-jan-03`}
+	{`wget -O ~/.local/bin/subspace-node https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-14/subspace-node-ubuntu-aarch64-mainnet-2025-jan-14`}
 	</CodeBlock>
 	Farmer:
 	<CodeBlock language="shell-session">
-	{`wget -O ~/.local/bin/subspace-farmer https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-03/subspace-farmer-ubuntu-aarch64-mainnet-2025-jan-03`}
+	{`wget -O ~/.local/bin/subspace-farmer https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-14/subspace-farmer-ubuntu-aarch64-mainnet-2025-jan-14`}
 	</CodeBlock>
 </details>
 

--- a/docs/farming-&-staking/farming/advanced-cli/platforms/_windows.mdx
+++ b/docs/farming-&-staking/farming/advanced-cli/platforms/_windows.mdx
@@ -12,14 +12,14 @@ If you face an error where the node outputs nothing and no error code is given i
 <div className={`${styles.buttons} ${styles.flexContainer}`}>
   <Link
     className="button button--secondary"
-    to="https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-03/subspace-node-windows-x86_64-skylake-mainnet-2025-jan-03.exe"
+    to="https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-14/subspace-node-windows-x86_64-skylake-mainnet-2025-jan-14.exe"
     style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
     <span style={{ fontSize: '20px' }}>Node Executable</span>
     <span style={{ fontSize: '14px' }}>(Skylake+ CPU)</span>
   </Link>
   <Link
     className="button button--secondary"
-    to="https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-03/subspace-farmer-windows-x86_64-skylake-mainnet-2025-jan-03.exe"
+    to="https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-14/subspace-farmer-windows-x86_64-skylake-mainnet-2025-jan-14.exe"
     style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
     <span style={{ fontSize: '20px' }}>Farmer Executable</span>
     <span style={{ fontSize: '14px' }}>(Skylake+ CPU)</span>
@@ -29,14 +29,14 @@ If you face an error where the node outputs nothing and no error code is given i
 <div className={`${styles.buttons} ${styles.flexContainer}`}>
   <Link
     className="button button--secondary"
-    to="https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-03/subspace-node-windows-x86_64-v2-mainnet-2025-jan-03.exe"
+    to="https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-14/subspace-node-windows-x86_64-v2-mainnet-2025-jan-14.exe"
     style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
     <span style={{ fontSize: '20px' }}>Node Executable</span>
     <span style={{ fontSize: '14px' }}>(Legacy CPU)</span>
   </Link>
   <Link
     className="button button--secondary"
-    to="https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-03/subspace-farmer-windows-x86_64-v2-mainnet-2025-jan-03.exe"
+    to="https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-14/subspace-farmer-windows-x86_64-v2-mainnet-2025-jan-14.exe"
     style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
     <span style={{ fontSize: '20px' }}>Farmer Executable</span>
     <span style={{ fontSize: '14px' }}>(Legacy CPU)</span>
@@ -59,7 +59,7 @@ This is because the application is trying to access the internet. This is expect
 ```powershell
 # Replace `INSERT_YOUR_ID` with a nickname you choose
 # Copy all of the lines below, they are all part of the same command
-.\subspace-node-windows-x86_64-skylake-mainnet-2025-jan-03.exe `
+.\subspace-node-windows-x86_64-skylake-mainnet-2025-jan-14.exe `
   run `
   --chain mainnet `
   --base-path NODE_DATA_PATH `
@@ -103,7 +103,7 @@ Using **run**, setting **--base-path** and specifying **--chain** is mandatory.
   # Replace `PATH_TO_FARM` with location where you want you store plot files
   # Replace `WALLET_ADDRESS` below with your account address from Polkadot.js wallet
   # Replace `PLOT_SIZE` with plot size in gigabytes or terabytes, for example 100G or 2T (but leave at least 60G of disk space for node and some for OS)
-  .\subspace-farmer-windows-x86_64-skylake-mainnet-2025-jan-03.exe farm --reward-address WALLET_ADDRESS path=PATH_TO_FARM,size=PLOT_SIZE
+  .\subspace-farmer-windows-x86_64-skylake-mainnet-2025-jan-14.exe farm --reward-address WALLET_ADDRESS path=PATH_TO_FARM,size=PLOT_SIZE
 ```
 
 2. You should see something similar in the terminal:

--- a/docs/farming-&-staking/staking/operators/platforms/_linux.mdx
+++ b/docs/farming-&-staking/staking/operators/platforms/_linux.mdx
@@ -10,7 +10,7 @@ import styles from '@site/src/pages/index.module.css';
 <div className={`${styles.buttons} ${styles.flexContainer}`}>
   <Link
     className="button button--secondary"
-    to="https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-03/subspace-node-ubuntu-x86_64-skylake-mainnet-2025-jan-03"
+    to="https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-14/subspace-node-ubuntu-x86_64-skylake-mainnet-2025-jan-14"
     style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
     <span style={{ fontSize: '20px' }}>Node Executable</span>
     <span style={{ fontSize: '14px' }}>(Skylake+ CPU)</span>
@@ -20,7 +20,7 @@ import styles from '@site/src/pages/index.module.css';
 <div className={`${styles.buttons} ${styles.flexContainer}`}>
   <Link
     className="button button--secondary"
-    to="https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-03/subspace-node-ubuntu-x86_64-v2-mainnet-2025-jan-03"
+    to="https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-14/subspace-node-ubuntu-x86_64-v2-mainnet-2025-jan-14"
     style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
     <span style={{ fontSize: '20px' }}>Node Executable</span>
     <span style={{ fontSize: '14px' }}>(Legacy CPU)</span>
@@ -30,7 +30,7 @@ import styles from '@site/src/pages/index.module.css';
 <div className={`${styles.buttons} ${styles.flexContainer}`}>
   <Link
     className="button button--secondary"
-    to="https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-03/subspace-node-ubuntu-aarch64-mainnet-2025-jan-03"
+    to="https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-14/subspace-node-ubuntu-aarch64-mainnet-2025-jan-14"
     style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
     <span style={{ fontSize: '20px' }}>Node Executable</span>
     <span style={{ fontSize: '14px' }}>(Aarch64/Raspberry Pi)</span>

--- a/docs/farming-&-staking/staking/operators/platforms/_macos.mdx
+++ b/docs/farming-&-staking/staking/operators/platforms/_macos.mdx
@@ -7,7 +7,7 @@ import styles from '@site/src/pages/index.module.css';
 <div className={`${styles.buttons} ${styles.flexContainer}`}>
   <Link
     className="button button--secondary"
-    to="https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-03/subspace-node-macos-aarch64-mainnet-2025-jan-03.zip"
+    to="https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-14/subspace-node-macos-aarch64-mainnet-2025-jan-14.zip"
     style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
     <span style={{ fontSize: '20px' }}>Node Executable</span>
     <span style={{ fontSize: '14px' }}>(Apple CPU)</span>

--- a/docs/farming-&-staking/staking/operators/platforms/_windows.mdx
+++ b/docs/farming-&-staking/staking/operators/platforms/_windows.mdx
@@ -8,7 +8,7 @@ import styles from '@site/src/pages/index.module.css';
 <div className={`${styles.buttons} ${styles.flexContainer}`}>
   <Link
     className="button button--secondary"
-    to="https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-03/subspace-node-windows-x86_64-skylake-mainnet-2025-jan-03.exe"
+    to="https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-14/subspace-node-windows-x86_64-skylake-mainnet-2025-jan-14.exe"
     style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
     <span style={{ fontSize: '20px' }}>Node Executable</span>
     <span style={{ fontSize: '14px' }}>(Skylake+ CPU)</span>
@@ -18,7 +18,7 @@ import styles from '@site/src/pages/index.module.css';
 <div className={`${styles.buttons} ${styles.flexContainer}`}>
   <Link
     className="button button--secondary"
-    to="https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-03/subspace-node-windows-x86_64-v2-mainnet-2025-jan-03.exe"
+    to="https://github.com/autonomys/subspace/releases/download/mainnet-2025-jan-14/subspace-node-windows-x86_64-v2-mainnet-2025-jan-14.exe"
     style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
     <span style={{ fontSize: '20px' }}>Node Executable</span>
     <span style={{ fontSize: '14px' }}>(Legacy CPU)</span>


### PR DESCRIPTION
In line with release of https://github.com/autonomys/subspace/releases/tag/mainnet-2025-jan-14.