### PR TITLE
Fix references of tSSC to tAI3

### DIFF
--- a/docs/farming-&-staking/staking/operators/register-operator.mdx
+++ b/docs/farming-&-staking/staking/operators/register-operator.mdx
@@ -217,7 +217,7 @@ You should see the node start successfully and begin syncing.
 
 :::info
 It's crucial to fully sync your node before registering as an operator. Please follow the commands in the ***Start the domain operator*** node section and only register as an operator once your node is fully synced. If many operators are registered but their nodes are still syncing or offline, it can adversely affect the speed of block production in the domain.
-You are required to have at least 100 tSSC in order to register your operator.
+You are required to have at least 100 tAI3 in order to register your operator. You can obtain tAI3 by farming on the taurus network.
 :::
 
 
@@ -246,7 +246,7 @@ You are required to have at least 100 tSSC in order to register your operator.
 ![NStaking-15](/img/doc-imgs/operators-staking/NStaking-15.png)
 
 :::info
-Make sure to specify a Minimum Nominator Stake of at least 1 tSSC.
+Make sure to specify a Minimum Nominator Stake of at least 1 tAI3.
 :::
 
 --This will need a new image once we have the gemini text replaced with Taurus text


### PR DESCRIPTION
In the staking instructions, there were two leftover references to tSSC.