### PR TITLE
Update Taurus operator version

### DIFF
--- a/docs/farming-&-staking/staking/operators/platforms/_linux.mdx
+++ b/docs/farming-&-staking/staking/operators/platforms/_linux.mdx
@@ -10,7 +10,7 @@ import styles from '@site/src/pages/index.module.css';
 <div className={`${styles.buttons} ${styles.flexContainer}`}>
   <Link
     className="button button--secondary"
-    to="https://github.com/autonomys/subspace/releases/download/taurus-2025-jan-28/subspace-node-ubuntu-x86_64-skylake-taurus-2025-jan-28"
+    to="https://github.com/autonomys/subspace/releases/download/taurus-2025-march-05/subspace-node-ubuntu-x86_64-skylake-taurus-2025-march-05"
     style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
     <span style={{ fontSize: '20px' }}>Node Executable</span>
     <span style={{ fontSize: '14px' }}>(Skylake+ CPU)</span>
@@ -20,7 +20,7 @@ import styles from '@site/src/pages/index.module.css';
 <div className={`${styles.buttons} ${styles.flexContainer}`}>
   <Link
     className="button button--secondary"
-    to="https://github.com/autonomys/subspace/releases/download/taurus-2025-jan-28/subspace-node-ubuntu-x86_64-v2-taurus-2025-jan-28"
+    to="https://github.com/autonomys/subspace/releases/download/taurus-2025-march-05/subspace-node-ubuntu-x86_64-v2-taurus-2025-march-05"
     style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
     <span style={{ fontSize: '20px' }}>Node Executable</span>
     <span style={{ fontSize: '14px' }}>(Legacy CPU)</span>
@@ -30,7 +30,7 @@ import styles from '@site/src/pages/index.module.css';
 <div className={`${styles.buttons} ${styles.flexContainer}`}>
   <Link
     className="button button--secondary"
-    to="https://github.com/autonomys/subspace/releases/download/taurus-2025-jan-28/subspace-node-ubuntu-aarch64-taurus-2025-jan-28"
+    to="https://github.com/autonomys/subspace/releases/download/taurus-2025-march-05/subspace-node-ubuntu-aarch64-taurus-2025-march-05"
     style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
     <span style={{ fontSize: '20px' }}>Node Executable</span>
     <span style={{ fontSize: '14px' }}>(Aarch64/Raspberry Pi)</span>

--- a/docs/farming-&-staking/staking/operators/platforms/_macos.mdx
+++ b/docs/farming-&-staking/staking/operators/platforms/_macos.mdx
@@ -7,7 +7,7 @@ import styles from '@site/src/pages/index.module.css';
 <div className={`${styles.buttons} ${styles.flexContainer}`}>
   <Link
     className="button button--secondary"
-    to="https://github.com/autonomys/subspace/releases/download/taurus-2025-jan-28/subspace-node-macos-aarch64-taurus-2025-jan-28.zip"
+    to="https://github.com/autonomys/subspace/releases/download/taurus-2025-march-05/subspace-node-macos-aarch64-taurus-2025-march-05.zip"
     style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
     <span style={{ fontSize: '20px' }}>Node Executable</span>
     <span style={{ fontSize: '14px' }}>(Apple CPU)</span>

--- a/docs/farming-&-staking/staking/operators/platforms/_windows.mdx
+++ b/docs/farming-&-staking/staking/operators/platforms/_windows.mdx
@@ -8,7 +8,7 @@ import styles from '@site/src/pages/index.module.css';
 <div className={`${styles.buttons} ${styles.flexContainer}`}>
   <Link
     className="button button--secondary"
-    to="https://github.com/autonomys/subspace/releases/download/taurus-2025-jan-28/subspace-node-windows-x86_64-skylake-taurus-2025-jan-28.exe"
+    to="https://github.com/autonomys/subspace/releases/download/taurus-2025-march-05/subspace-node-windows-x86_64-skylake-taurus-2025-march-05.exe"
     style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
     <span style={{ fontSize: '20px' }}>Node Executable</span>
     <span style={{ fontSize: '14px' }}>(Skylake+ CPU)</span>
@@ -18,7 +18,7 @@ import styles from '@site/src/pages/index.module.css';
 <div className={`${styles.buttons} ${styles.flexContainer}`}>
   <Link
     className="button button--secondary"
-    to="https://github.com/autonomys/subspace/releases/download/taurus-2025-jan-28/subspace-node-windows-x86_64-v2-taurus-2025-jan-28.exe"
+    to="https://github.com/autonomys/subspace/releases/download/taurus-2025-march-05/subspace-node-windows-x86_64-v2-taurus-2025-march-05.exe"
     style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
     <span style={{ fontSize: '20px' }}>Node Executable</span>
     <span style={{ fontSize: '14px' }}>(Legacy CPU)</span>

--- a/docs/farming-&-staking/staking/operators/register-operator.mdx
+++ b/docs/farming-&-staking/staking/operators/register-operator.mdx
@@ -161,7 +161,7 @@ by replacing `your_operator_id` with your operator_id obtained when registering 
 <CodeBlock>
 {`services:
   node:
-    # Replace snapshot-DATE with the latest release (like mainnet-2025-jan-28)
+    # Replace snapshot-DATE with the latest release (like mainnet-2025-march-05)
     image: ghcr.io/autonomys/node:snapshot-DATE
     volumes:
 # Instead of specifying volume (which will store data in /var/lib/docker), you can


### PR DESCRIPTION
In line with release of https://github.com/autonomys/subspace/releases/tag/taurus-2025-march-05.