### PR TITLE
Fix PolkadotJS guide

### DIFF
--- a/docs/farming-&-staking/staking/additional-guides/polkadot-apps.mdx
+++ b/docs/farming-&-staking/staking/additional-guides/polkadot-apps.mdx
@@ -30,6 +30,7 @@ These extrinsics can be submitted on [Polkadot](https://polkadot.js.org/apps/?rp
 4. Enter the `OperatorId` you wish to nominate.  
 5. Set the nomination `amount` in **Shannons**. For reference, 100 tAI3 equals 100 followed by 18 zeros.  
 6. Click `Submit Transaction` and sign the extrinsic with your supported [wallet](/wallets).
+
 </details>
 
 ## Register an Operator
@@ -46,6 +47,7 @@ These extrinsics can be submitted on [Polkadot](https://polkadot.js.org/apps/?rp
 6. Set the minimum nominator stake required to participate under this operator in **Shannons**. For reference, 10 tAI3 is represented as 10 followed by 18 zeros. The value must be an integer equal to or greater than 1 token.
 7. Set the nomination tax percentage to be collected from nominators participating under this operator. The value must be an integer equal to or greater than 0.
 8. Click `Submit Transaction` and sign the extrinsic with your supported [wallet](/wallets).
+
 </details>
 
 
@@ -65,6 +67,7 @@ It will take **14,400 domain blocks** from a successful withdrawal before you ca
 4. Enter the `OperatorId` you wish to nominate.  
 5. Select `All` to withdraw the full amount, or choose `Stake` to withdraw only a portion. If you choose to withdraw a partial stake, enter 80% of the amount you wish to withdraw. The remaining 20% is held in a storage fund and will be refunded automatically. For example, to withdraw 100 tAI3, you would enter (100 * 0.80), which equals 80 followed by 18 zeros as the amount is in **Shannons**.
 6. Click `Submit Transaction` and sign the extrinsic with your supported [wallet](/wallets).
+
 </details>
 
 
@@ -83,4 +86,5 @@ It will take **14,400 domain blocks** from a successful withdrawal before you ca
 3. Select `unlockNominator`.  
 4. Enter the `OperatorId` you wish to nominate.  
 5. Click `Submit Transaction` and sign the extrinsic with your supported [wallet](/wallets).
+
 </details>


### PR DESCRIPTION
Add a line between markdown and HTML elements to satisfy MDX rules.

Just like the streams from The Ghostbuster's proton packs, they must never touch.