### PR TITLE
fix(css): correct error-state selector & spacing step

### DIFF
--- a/src/components/DockerFileGenerator/DockerFileGenerator.module.css
+++ b/src/components/DockerFileGenerator/DockerFileGenerator.module.css
@@ -42,7 +42,7 @@
 
 .compose-generator-form__input,
 .compose-generator-form__label,
-.compose-generator-form__error-text,
+.compose-generator-form__text--error,
 .compose-generator-form__button--primary {
     font-family: var(--ifm-font-family-base);
     font-size: 1.008rem;
@@ -129,7 +129,7 @@
 
 html[data-theme='dark'] .compose-generator-form__card {
     border-radius: 0.618rem;
-    box-shadow: 0rem 0.077rem 0.304rem rgba(255, 255, 255, 0.08); 
+    box-shadow: 0rem 0.077rem 0.309rem rgba(255, 255, 255, 0.08); 
 }
 
 html[data-theme='dark'] .compose-generator-form__label--glow {


### PR DESCRIPTION

* Renamed `.compose-generator-form__error-text` → `.compose-generator-form__text--error` to follow BEM modifier syntax, enabling global error styles to apply.
* Replaced `0.304rem` with `0.309rem` to restore golden‑ratio spacing consistency across components.






