### PR TITLE
Cleanup/documentation updates

### DIFF
--- a/docs/farming-&-staking/farming/cli/cli-tips.mdx
+++ b/docs/farming-&-staking/farming/cli/cli-tips.mdx
@@ -198,7 +198,7 @@ If you are having issues with running a node or farmer for Autonomys, feel free 
 
 ## Timekeepers
 
-Gemini-3g introduces Proof-of-Time and a new, optional role has been added to the node. Timekeepers help run PoT to ensure the security of the network. Timekeeping requires a high-performance core CPU but can be undertaken by any node runner. You can enable timekeeping with the following commands. 
+Proof-of-Time is secured by Timekeepers, an optional role that has been added to the node. Timekeepers help run PoT to ensure the security of the network. Timekeeping requires a high-performance core CPU but can be undertaken by any node runner. You can enable timekeeping with the following commands. 
 - `--timekeeper`: To enable timekeeping on the node
 - `--timekeeper-cpu-cores`: To specify which cores the Timekeeper will run on. 
 

--- a/docs/farming-&-staking/farming/cli/taurus-network.mdx
+++ b/docs/farming-&-staking/farming/cli/taurus-network.mdx
@@ -20,7 +20,7 @@ import TabItem from '@theme/TabItem';
 
 ## Network Description
 
-Taurus is our permanent test network that started up in October of 2024. The purpose of this page is to highlight any differences between Taurus and our mainnet.
+Taurus is our permanent testnet that started up in October of 2024. The purpose of this page is to highlight any differences between the Taurus testnet and our mainnet.
 
 ## Chain Parameter
 

--- a/docs/farming-&-staking/staking/additional-guides/tips-operator.mdx
+++ b/docs/farming-&-staking/staking/additional-guides/tips-operator.mdx
@@ -189,12 +189,6 @@ volumes:
 </TabItem>
 </Tabs>
 
-:::note
-If you're running an operator node for **AutoID domain**, add the following bootstrap node to the list of domain arguments:
-
---bootstrap-node /dns/bootstrap-0.autoid.gemini-3h.subspace.network/tcp/30334/p2p/12D3KooWFoiz2iTkmnnSqiL2oQRhGzaqgtUjYNz2jyWKQqgPXgx9
-:::
-
 You should see the node start successfully and begin syncing. 
 
 ![Staking-28](/img/doc-imgs/operators-staking/Staking-28.png)

--- a/docs/farming-&-staking/staking/intro.md
+++ b/docs/farming-&-staking/staking/intro.md
@@ -14,7 +14,7 @@ keywords:
 
 :::warning Operator and Staking Availability
 Running an Operator and staking are only available on the Taurus testnet.  
-Availability on the mainnet is planned for Phase 2. For further details, please refer to our [Phased Launch Roadmap](https://forum.autonomys.xyz/t/4831).
+Availability on mainnet is planned for Phase 2. For further details, please refer to our [Phased Launch Roadmap](https://forum.autonomys.xyz/t/4831).
 :::
 
 ## Decoupled Execution Framework
@@ -49,7 +49,7 @@ For more information on how Subspace separates consensus and computation, check 
 ### Requirements
 
 :::warning Requirement Changes
-Hardware requirements are lowered for testing but will likely increase on the mainnet.
+Hardware requirements are lowered for testing but will likely increase on mainnet.
 :::
 
 #### Operating System

--- a/docs/farming-&-staking/staking/intro.md
+++ b/docs/farming-&-staking/staking/intro.md
@@ -14,7 +14,7 @@ keywords:
 
 :::warning Operator and Staking Availability
 Running an Operator and staking are only available on the Taurus testnet.  
-Availability on the mainnet is planned for Phase 2. For further details, please refer to our [Phased Launch Roadmap](https://forum.autonomys.xyz/t/4414).
+Availability on the mainnet is planned for Phase 2. For further details, please refer to our [Phased Launch Roadmap](https://forum.autonomys.xyz/t/4831).
 :::
 
 ## Decoupled Execution Framework

--- a/docs/farming-&-staking/staking/intro.md
+++ b/docs/farming-&-staking/staking/intro.md
@@ -13,7 +13,7 @@ keywords:
 ---
 
 :::warning Operator and Staking Availability
-Running an Operator and staking are only available on the Taurus and Gemini-3h testnets.  
+Running an Operator and staking are only available on the Taurus testnet.  
 Availability on the mainnet is planned for Phase 2. For further details, please refer to our [Phased Launch Roadmap](https://forum.autonomys.xyz/t/4414).
 :::
 

--- a/docs/farming-&-staking/staking/operators/register-operator.mdx
+++ b/docs/farming-&-staking/staking/operators/register-operator.mdx
@@ -24,7 +24,7 @@ import LinuxPage from '/docs/farming-&-staking/staking/operators/platforms/_linu
 Download `Subspace Node` for your respective operating system.
 
 :::info Taurus Network Only
-Currently, only running and registering an operator on the Taurus test network is supported.
+Currently, only running and registering an operator on the Taurus testnet is supported.
 :::
 
 <Tabs groupId="OS">

--- a/docs/farming-&-staking/wallets/polkadot.md
+++ b/docs/farming-&-staking/wallets/polkadot.md
@@ -82,7 +82,7 @@ If you face any trouble or would like to learn about other features for Polkadot
 
     ![trouble-1](/img/doc-imgs/polkadot/trouble-1.png)
 
-- You can see your Autonomys Mainnet public address via the `...` menu and setting the `Allow Use on Any Chain` dropdown to `Autonomys Mainnet`, once you exit you will see the public address now starts with `su`
+- You can see your Autonomys mainnet public address via the `...` menu and setting the `Allow Use on Any Chain` dropdown to `Autonomys mainnet`, once you exit you will see the public address now starts with `su`
 
     ![trouble-2](/img/doc-imgs/polkadot/trouble-2.png)
 
@@ -116,7 +116,7 @@ If you face any trouble or would like to learn about other features for Polkadot
 
     ![trouble-8](/img/doc-imgs/polkadot/trouble-8.png)
 
-7. You will now see `Autonomys Mainnet` as an option on the `Allow use on any chain` dropdown. 
+7. You will now see `Autonomys mainnet` as an option on the `Allow use on any chain` dropdown. 
 
     ![trouble-9](/img/doc-imgs/polkadot/trouble-9.png)
 

--- a/docs/farming-&-staking/wallets/subwallet.md
+++ b/docs/farming-&-staking/wallets/subwallet.md
@@ -59,7 +59,7 @@ If you would like to Import an **Existing** Wallet, then select `Import an accou
 
 ![step-9](/img/doc-imgs/subwallet/Subwallet-7.png)
 
-## Connect wallet to Autonomys Mainnet and find wallet public address
+## Connect wallet to Autonomys mainnet and find wallet public address
 
 1. Open SubWallet, scroll all the way down and click on *Manage tokens*.
 
@@ -70,7 +70,7 @@ If you would like to Import an **Existing** Wallet, then select `Import an accou
 ![wallet-2](/img/doc-imgs/subwallet/Subwallet-9.png)
 
 3. In the search bar, start typing the name of the network, e.g. Autonomys.
-You will see two networks - **Mainnet** and **Taurus** test network.
+You will see two networks - **mainnet** and **Taurus** testnet.
 
 ![wallet-3](/img/doc-imgs/subwallet/Subwallet-10.png)
 
@@ -91,7 +91,7 @@ This also can be helpful for in-development networks such as the Autonomys Netwo
 
 <details>
 <summary>📝 RPC endpoints</summary>
-#### Consensus (Mainnet)
+#### Consensus (mainnet)
 ```
     wss://rpc.mainnet.subspace.foundation/ws
 ```

--- a/docs/learn/faq.mdx
+++ b/docs/learn/faq.mdx
@@ -24,7 +24,7 @@ Find answers to the most frequently asked questions about the Autonomys Network,
 ### What are the current RPC endpoints? {#rpc-endpoints}
 <details>
 <summary>📝 RPC endpoints</summary>
-#### Consensus (Mainnet)
+#### Consensus (mainnet)
 ```
     wss://rpc.mainnet.subspace.foundation/ws
     wss://rpc-0.mainnet.autonomys.xyz/ws 
@@ -43,19 +43,19 @@ Find answers to the most frequently asked questions about the Autonomys Network,
 <small><sub>📅 Last Updated: 2025-05-30</sub></small>
 
 ### What happened to testnet tokens? {#testnet-tokens}
-📝 The testnet tokens (tSSC) earned during the various incentivized Gemini testnet phases were converted to mainnet tokens (AI3) at the time of the mainnet launch, and this conversion was included in the genesis block. The [Astral Testnet Rewards Checker](https://astral.autonomys.xyz/mainnet/testnet-rewards) allows you to see how much AI3 you were rewarded, proportional to your participation in the different testnet phases.  
-<small><sub>📅 Last Updated: 2025-01-25</sub></small>
+📝 The testnet tokens (tSSC) earned during the various incentivized Gemini testnet phases were converted to mainnet tokens (AI3) at the time of mainnet launch, and this conversion was included in the genesis block. The [Astral Testnet Rewards Checker](https://astral.autonomys.xyz/mainnet/testnet-rewards) allows you to see how much AI3 you were rewarded, proportional to your participation in the different testnet phases.  
+<small><sub>📅 Last Updated: 2025-05-30</sub></small>
 
 ### When TGE? {#tge}
 📝 Please see the [Mainnet Phase 2 Roadmap](https://forum.autonomys.xyz/t/4831) for more details.  
 <small><sub>📅 Last Updated: 2025-05-30</sub></small>
 
-### When will the mainnet launch? {#mainnet-launch}
-📝 The mainnet launched on November 6, 2024.  
-<small><sub>📆 Last Updated: 2025-01-25</sub></small>
+### When will mainnet launch? {#mainnet-launch}
+📝 Mainnet launched on November 6, 2024.  
+<small><sub>📅 Last Updated: 2025-05-30</sub></small>
 
 ### When will token transfers be enabled? {#token-transfers}
-📝 Token transfers will be enabled in Phase 2 of the mainnet, which will begin once all milestones are met. Please see the [Mainnet Phase 2 Roadmap](https://forum.autonomys.xyz/t/4831) for more details.  
+📝 Token transfers will be enabled in Phase 2 of mainnet, which will begin once all milestones are met. Please see the [Mainnet Phase 2 Roadmap](https://forum.autonomys.xyz/t/4831) for more details.  
 <small><sub>📅 Last Updated: 2025-05-30</sub></small>
 
 ## Farming<a id="farming"></a>

--- a/docs/learn/faq.mdx
+++ b/docs/learn/faq.mdx
@@ -39,13 +39,8 @@ Find answers to the most frequently asked questions about the Autonomys Network,
 ```
     wss://auto-evm.taurus.autonomys.xyz/ws
 ```
-
-#### Auto ID (Gemini Testnet)
-```
-    wss://autoid-0.gemini-3h.subspace.network/ws
-``` 
 </details>
-<small><sub>📅 Last Updated: 2025-04-18</sub></small>
+<small><sub>📅 Last Updated: 2025-05-30</sub></small>
 
 ### What happened to testnet tokens? {#testnet-tokens}
 📝 The testnet tokens (tSSC) earned during the various incentivized Gemini testnet phases were converted to mainnet tokens (AI3) at the time of the mainnet launch, and this conversion was included in the genesis block. The [Astral Testnet Rewards Checker](https://astral.autonomys.xyz/mainnet/testnet-rewards) allows you to see how much AI3 you were rewarded, proportional to your participation in the different testnet phases.  

--- a/docs/learn/faq.mdx
+++ b/docs/learn/faq.mdx
@@ -47,16 +47,16 @@ Find answers to the most frequently asked questions about the Autonomys Network,
 <small><sub>📅 Last Updated: 2025-01-25</sub></small>
 
 ### When TGE? {#tge}
-📝 Please see the [Mainnet Phase 2 Roadmap](https://forum.autonomys.xyz/t/4755) for more details.  
-<small><sub>📅 Last Updated: 2025-03-26</sub></small>
+📝 Please see the [Mainnet Phase 2 Roadmap](https://forum.autonomys.xyz/t/4831) for more details.  
+<small><sub>📅 Last Updated: 2025-05-30</sub></small>
 
 ### When will the mainnet launch? {#mainnet-launch}
 📝 The mainnet launched on November 6, 2024.  
 <small><sub>📆 Last Updated: 2025-01-25</sub></small>
 
 ### When will token transfers be enabled? {#token-transfers}
-📝 Token transfers will be enabled in Phase 2 of the mainnet, which will begin once all milestones are met. Please see the [Mainnet Phase 2 Roadmap](https://forum.autonomys.xyz/t/4755) for more details.  
-<small><sub>📅 Last Updated: 2025-03-26</sub></small>
+📝 Token transfers will be enabled in Phase 2 of the mainnet, which will begin once all milestones are met. Please see the [Mainnet Phase 2 Roadmap](https://forum.autonomys.xyz/t/4831) for more details.  
+<small><sub>📅 Last Updated: 2025-05-30</sub></small>
 
 ## Farming<a id="farming"></a>
 ---


### PR DESCRIPTION
  - Remove deprecated Gemini testnet references
    - Remove Gemini-3g reference from Timekeepers section
    - Remove Auto ID (Gemini Testnet) RPC endpoint
    - Remove AutoID domain bootstrap node
    - Update testnet availability to only mention Taurus testnet

  - Update Mainnet Phase 2 Roadmap forum links
    - Update forum links from t/4755 and t/4414 to t/4831
    - Update last modified dates to reflect changes

  - Standardize mainnet and testnet terminology
    - Change "the mainnet" to "mainnet" throughout docs
    - Change "Mainnet" to "mainnet" when not at start of sentence
    - Change "test network" to "testnet" for consistency
    - Standardize "Autonomys Mainnet" to "Autonomys mainnet"
