### PR TITLE
Hide develop section from sidebar

### DIFF
--- a/docs/develop/_category_.json
+++ b/docs/develop/_category_.json
@@ -1,5 +1,6 @@
 {
     "label": "Develop",
     "position": 3,
-    "link": null
+    "link": null,
+    "className": "sidebar-hidden"
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -228,3 +228,8 @@ html[data-theme='dark'] .docusaurus-highlight-code-line {
 [data-theme='dark'] img[src$='#gh-light-mode-only'] {
   display: none;
 }
+
+/* Hide sidebar categories marked as sidebar-hidden */
+.sidebar-hidden {
+  display: none !important;
+}


### PR DESCRIPTION
Hide develop section from sidebar to avoid maintaining parallel category structures between docs and develop.autonomys.xyz sites.