### PR TITLE
Register ContentBlock components in MDXComponents provider

### DIFF
--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -3,10 +3,28 @@ import MDXComponents from '@theme-original/MDXComponents';
 import Icon from '@site/src/components/Icon';
 import Badge from '@site/src/components/Badge';
 import TabLabel from '@site/src/components/TabLabel';
+import { 
+  ContentBlock, 
+  ContentGroup, 
+  ContentText, 
+  ContentSubtitle, 
+  ContentList, 
+  ContentListItem, 
+  ContentCode, 
+  ContentFooter 
+} from '@site/src/components/ContentBlock';
 
 export default {
   ...MDXComponents,
   Icon,
   Badge,
   TabLabel,
+  ContentBlock,
+  ContentGroup,
+  ContentText,
+  ContentSubtitle,
+  ContentList,
+  ContentListItem,
+  ContentCode,
+  ContentFooter,
 };


### PR DESCRIPTION
This fix ensures that custom ContentBlock components (ContentList and ContentListItem) are properly recognized and rendered during the build process. Previously, these components were showing up as raw JSX code on /staking/operator/polkadot instead of rendered HTML because they weren't registered with the MDX provider.