### PR TITLE
replace broken firstcontributions link

### DIFF
--- a/docs/participate/contribute/intro.md
+++ b/docs/participate/contribute/intro.md
@@ -65,7 +65,7 @@ Congratulations! You have just submitted your first pull request!
 No worries! We all start somewhere. There are several videos and resources online to show various ways to use GitHub.
 Check out some of these amazing guides to help get you familiar with GitHub and contributing.
 - [First Contributions - Terminal](https://github.com/firstcontributions/first-contributions)
-- [First Contributions - GitHub Desktop](https://github.com/firstcontributions/first-contributions/blob/master/gui-tool-tutorials/github-desktop-tutorial.md)
+- [First Contributions - GitHub Desktop](https://github.com/firstcontributions/first-contributions/blob/main/docs/gui-tool-tutorials/github-desktop-tutorial.md)
 - [How to Contribute to an Open Source Project on GitHub](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github)
 
 ## Advanced Fix


### PR DESCRIPTION
Hey devs, replace broken link in docs/participate/contribute/intro.md

https://github.com/firstcontributions/first-contributions/blob/master/gui-tool-tutorials/github-desktop-tutorial.md - OLD
https://github.com/firstcontributions/first-contributions/blob/main/docs/gui-tool-tutorials/github-desktop-tutorial.md - NEW