### PR TITLE
Update FAQ to reflect mainnet Phase-2 activation and token transfers going live

### DIFF
--- a/docs/learn/faq.mdx
+++ b/docs/learn/faq.mdx
@@ -88,34 +88,25 @@ wss://rpc-0.mainnet.autonomys.xyz/ws`}
   </ContentBlock>
 
   <ContentBlock 
-    title="When TGE?" 
-    slug="tge"
-    lastUpdated="2025-05-30"
-  >
-    <ContentText>
-      Please see the <Link to="https://forum.autonomys.xyz/t/4831">Mainnet Phase 2 Roadmap</Link> for more details.
-    </ContentText>
-  </ContentBlock>
-
-  <ContentBlock 
-    title="When will mainnet launch?" 
+    title="When did mainnet launch?" 
     slug="mainnet-launch"
-    lastUpdated="2025-05-30"
+    lastUpdated="2025-07-30"
   >
     <ContentText>
-      Mainnet launched on November 6, 2024.
+      The Autonomys Network mainnet officially launched on November 6, 2024, marking the beginning of Phase-1. This initial phase focused on establishing the network's core infrastructure and consensus mechanism, with token transfers initially disabled until the subsequent Phase-2 activation.
     </ContentText>
   </ContentBlock>
 
   <ContentBlock 
-    title="When will token transfers be enabled?" 
-    slug="token-transfers"
-    lastUpdated="2025-05-30"
+    title="When were token transfers enabled?" 
+    slug="tge"
+    lastUpdated="2025-07-30"
   >
     <ContentText>
-      Token transfers will be enabled in Phase 2 of mainnet, which will begin once all milestones are met. Please see the <Link to="https://forum.autonomys.xyz/t/4831">Mainnet Phase 2 Roadmap</Link> for more details.
+      The Subspace Foundation activated mainnet transfers at block 3,585,226 on July 16th, 2025. This activation enabled native $AI3 token transfers on the Autonomys Network and marked the official beginning of Mainnet Phase-2. The economic layer of the protocol was unlocked at this time, allowing for on-chain $AI3 transactions. This milestone represented the culmination of years of research, engineering, testing, and community coordination.
     </ContentText>
   </ContentBlock>
+
 </ContentGroup>
 
 <ContentGroup title="Farming" icon={<Icon icon={ICONS.FARMER} />} id="farming">


### PR DESCRIPTION
  - Updated token transfer status to reflect activation on July 16th, 2025 at block 3,585,226
  - Converted future tense questions to past tense for both TGE and mainnet launch
  - Removed outdated "When will token transfers be enabled?" section