### PR TITLE
Add FAQ entries for Drip & Zealy community engagement

### DIFF
--- a/docs/community/engage/drip-zealy/faq.mdx
+++ b/docs/community/engage/drip-zealy/faq.mdx
@@ -141,6 +141,20 @@ This FAQ stays up-to-date with platform changes, new features, and insights from
   </ContentBlock>
 </ContentGroup>
 
+## <Icon icon={ICONS.WALLET} /> Wallet & Technical
+
+<ContentGroup>
+  <ContentBlock 
+    title="Where can I find the consensus wallet address and what is it?" 
+    slug="consensus-wallet"
+    lastUpdated="2025-08-12"
+  >
+    <ContentText>
+      You can use the AI3 address depending on your wallet type. If you're using the Polkadot extension, make sure to enable the "allow use on any chain" network setting, which will also work for consensus transactions.
+    </ContentText>
+  </ContentBlock>
+</ContentGroup>
+
 ## <Icon icon={ICONS.COMMUNITY} /> Roles & Progression
 
 <ContentGroup>
@@ -187,6 +201,27 @@ This FAQ stays up-to-date with platform changes, new features, and insights from
   </ContentBlock>
 
   <ContentBlock 
+    title="What are the benefits of the Autonaut career progression?" 
+    slug="autonaut-benefits"
+    lastUpdated="2025-08-12"
+  >
+    <ContentText>
+      The Autonaut career ladder includes six progression levels:
+    </ContentText>
+    <ContentList>
+      <ContentListItem>Autonaut Cadet</ContentListItem>
+      <ContentListItem>Autonaut</ContentListItem>
+      <ContentListItem>Senior Autonaut</ContentListItem>
+      <ContentListItem>Autonaut Veteran</ContentListItem>
+      <ContentListItem>Autonaut Captain</ContentListItem>
+      <ContentListItem>Autonaut Admiral</ContentListItem>
+    </ContentList>
+    <ContentText>
+      Reaching higher levels unlocks exclusive benefits and community recognition. Specific rewards are being finalized by the core team.
+    </ContentText>
+  </ContentBlock>
+
+  <ContentBlock 
     title="What will I get for reaching the top career roles?" 
     slug="top-roles"
     lastUpdated="2025-07-04"
@@ -194,6 +229,52 @@ This FAQ stays up-to-date with platform changes, new features, and insights from
     <ContentText>
       Exciting rewards and exclusive benefits are being planned for top career roles. Stay tuned for announcements about special perks, early access opportunities, and other premium benefits for our most dedicated community members!
     </ContentText>
+  </ContentBlock>
+
+  <ContentBlock 
+    title="How can I obtain a specific role?" 
+    slug="obtain-specific-role"
+    lastUpdated="2025-08-12"
+  >
+    <ContentText>
+      To get the Aspiring Autonaut role, complete the onboarding campaign on the Zealy platform. All subsequent career roles are available for purchase in the Drip shop using points that are transferred monthly from Zealy to the Drip platform.
+    </ContentText>
+    <ContentFooter>
+      <div className="releases-container">
+        <ActionButton 
+          to="https://discord.com/channels/864285291518361610/1313713640297336843" 
+          title="Visit Shop" 
+          subtitle="#drip-shop" 
+          icon={ICONS.DISCORD} 
+          external 
+        />
+      </div>
+    </ContentFooter>
+  </ContentBlock>
+</ContentGroup>
+
+## <Icon icon={ICONS.HELP} /> Campaign Support
+
+<ContentGroup>
+  <ContentBlock 
+    title="How do I complete specific campaign tasks?" 
+    slug="campaign-tasks"
+    lastUpdated="2025-08-12"
+  >
+    <ContentText>
+      Each campaign task includes detailed instructions in the task description. If you have specific questions about a particular campaign or task, please reach out in our Discord community where our team can provide personalized assistance.
+    </ContentText>
+    <ContentFooter>
+      <div className="releases-container">
+        <ActionButton 
+          to="https://discord.com/channels/864285291518361610/1205230748479520778" 
+          title="Get Help" 
+          subtitle="#drip-zealy channel" 
+          icon={ICONS.DISCORD} 
+          external 
+        />
+      </div>
+    </ContentFooter>
   </ContentBlock>
 </ContentGroup>
 


### PR DESCRIPTION
New: Wallet & Technical section
- Added consensus wallet address guidance for AI3 and Polkadot extension usage

Enhanced: Roles & Progression section
- Added detailed Autonaut career progression (6 levels: Cadet → Admiral)
- Added specific role acquisition instructions (Zealy onboarding + Drip shop)
- Clarified benefits and rewards structure

New: Campaign Support section
- Added guidance for completing specific campaign tasks
- Provided clear escalation path to Discord community support