### PR TITLE
ci: bump actions/checkout to v5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       # Checkout the repository
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Setup Node.js environment
       - name: Use Node.js

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
     name: Install Dependencies
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: '22.14.0'
@@ -29,7 +29,7 @@ jobs:
     env:
       CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
     steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v5
         - uses: actions/setup-node@v4
           with:
             node-version: '22.14.0'
@@ -45,7 +45,7 @@ jobs:
     env:
       CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
     steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v5
         - uses: actions/setup-node@v4
           with:
             node-version: '22.14.0'
@@ -59,7 +59,7 @@ jobs:
     needs: [build-leaderboard, sync-localization]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: '22.14.0'


### PR DESCRIPTION
GitHub-hosted runners now use Node 24, so actions/checkout@v5 is required. Minimum runner version v2.327.1. Workflows only updated—no functional changes.

See: https://github.com/actions/checkout/releases/tag/v5.0.0