### PR TITLE
Replace Astral Explorer references with Subscan Explorer

### DIFF
--- a/docs/farming-&-staking/farming/additional-guides/verified-roles.mdx
+++ b/docs/farming-&-staking/farming/additional-guides/verified-roles.mdx
@@ -13,7 +13,7 @@ keywords:
 ---
 
 We are thrilled to announce new Verified Roles including **Verified Mainnet Farmer**, **Verified Taurus Farmer**, **Verified Taurus Operator**, and **Verified Taurus Nominator** on our [Discord server](https://autonomys.xyz/discord)!
-You can track your farmer through [Astral Block Explorer](https://astral.autonomys.xyz).
+You can track your farmer through [Subscan Block Explorer](https://autonomys.subscan.io).
 
 ## All Roles Currently Available
 

--- a/docs/farming-&-staking/farming/cli/cli-farming-cluster.mdx
+++ b/docs/farming-&-staking/farming/cli/cli-farming-cluster.mdx
@@ -156,7 +156,7 @@ Refer to `./subspace-farmer cluster controller --help` for an explanation of eac
 
 The Cache stores the blockchain's Archive History. For optimal performance, the cache must be large enough to hold this data locally. If the data isn't available in the cache, plotting may slow down as it has to be fetched from peers over the DSN. Currently, we recommend a minimum of 200GiB.
 
-The current Archive History Size can be found in the top cards on [Astral Block Explorer](https://astral.autonomys.xyz).
+The current Archive History Size can be found in the top cards on [Subscan Block Explorer](https://autonomys.subscan.io).
 
 :::
 

--- a/docs/farming-&-staking/farming/common-problems.mdx
+++ b/docs/farming-&-staking/farming/common-problems.mdx
@@ -181,7 +181,7 @@ These unexpected behaviors are not linked to specific components. In this sectio
     <ContentList>
       <ContentListItem>Ensure you are using the latest release of either <Link to="https://github.com/autonomys/space-acres/releases">Space Acres</Link> <Badge variant="recommended" text="Recommended" /> or the <Link to="https://github.com/autonomys/subspace/releases">CLI</Link></ContentListItem>
       <ContentListItem>Confirm that your farmer is active and on the highest block by checking our <Link to="https://telemetry.subspace.foundation">telemetry</Link> server</ContentListItem>
-      <ContentListItem>Check your balance using <Link to="https://astral.autonomys.xyz">Astral Block Explorer</Link> or the <Link to="https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc.mainnet.subspace.foundation%2Fws#/explorer">Polkadot Explorer</Link></ContentListItem>
+      <ContentListItem>Check your balance using <Link to="https://autonomys.subscan.io">Subscan Block Explorer</Link> or the <Link to="https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc.mainnet.subspace.foundation%2Fws#/explorer">Polkadot Explorer</Link></ContentListItem>
     </ContentList>
   </ContentBlock>
 </ContentGroup>

--- a/docs/farming-&-staking/farming/intro.mdx
+++ b/docs/farming-&-staking/farming/intro.mdx
@@ -124,9 +124,7 @@ Explore the Autonomys Network in depth with our variety of telemetry tools and b
 
 - **[Telemetry Server](https://telemetry.subspace.foundation)**: Get real-time insights into network activity and performance metrics. Ideal for monitoring the overall health and status of the Autonomys Network.
 
-- **[Astral Block Explorer](https://astral.autonomys.xyz)**: Our primary tool for viewing blocks, transactions, and network activity on the Autonomys Network. This explorer offers an intuitive interface and detailed information.
-
-- **[Subscan Block Explorer](https://autonomys.subscan.io/)**: An alternative block explorer providing detailed views of blocks, transactions, and network events. Subscan is known for its user-friendly interface and additional data analytics features.
+- **[Subscan Block Explorer](https://autonomys.subscan.io)**: Our primary tool for viewing blocks, transactions, and network activity on the Autonomys Network. Subscan is known for its user-friendly interface and additional data analytics features.
 
 - **[Polkadot.js Block Explorer](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc.mainnet.subspace.foundation%2Fws#/explorer)**: For users familiar with the Polkadot ecosystem, this explorer offers a seamless experience for exploring the Autonomys Network using the Polkadot.js interface.
 

--- a/docs/farming-&-staking/staking/additional-guides/polkadot-apps.mdx
+++ b/docs/farming-&-staking/staking/additional-guides/polkadot-apps.mdx
@@ -24,7 +24,7 @@ import Icon from '@site/src/components/Icon';
 import { ICONS } from '@site/src/constants';
 import { ContentGroup, ContentBlock, ContentText, ContentSubtitle, ContentList, ContentListItem, ContentCode, ContentFooter } from '@site/src/components/ContentBlock';
 
-This guide provides step-by-step instructions for submitting common types of extrinsics on the Autonomys Network using the Polkadot Apps interface. It is intended to help operators and nominators perform these actions directly via RPC calls as an alternative to using [Astral Block Explorer](https://astral.autonomys.xyz).
+This guide provides step-by-step instructions for submitting common types of extrinsics on the Autonomys Network using the Polkadot Apps interface. It is intended to help operators and nominators perform these actions directly via RPC calls.
 
 :::tip Polkadot Apps Interface
 These extrinsics can be submitted on [Polkadot Apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc-0.mainnet.autonomys.xyz%2Fws#/extrinsics) under **Developer > Extrinsics**.

--- a/docs/farming-&-staking/wallets/subwallet.mdx
+++ b/docs/farming-&-staking/wallets/subwallet.mdx
@@ -133,7 +133,7 @@ This also can be helpful for in-development networks such as the Autonomys Netwo
 - Block explorer
 - Crowdloan URL
 
-The only required option is the Provider URL. Adding an explorer is optional. The default block explorer for the Autonomys Network is [Astral Block Explorer](https://astral.autonomys.xyz).
+The only required option is the Provider URL. Adding an explorer is optional. The default block explorer for the Autonomys Network is [Subscan Block Explorer](https://autonomys.subscan.io).
 
 You can refer to the *RPC Endpoints* above for available provider URLs for the Autonomys Network.
     

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -122,8 +122,8 @@ Connect with the Autonomys community and explore our ecosystem:
   />
   
   <ResourceCard 
-    to="https://astral.autonomys.xyz" 
-    title="Astral Block Explorer" 
+    to="https://autonomys.subscan.io" 
+    title="Subscan Block Explorer" 
     subtitle="Explore network activity" 
     icon={ICONS.EXPLORER} 
   />

--- a/docs/learn/faq.mdx
+++ b/docs/learn/faq.mdx
@@ -45,7 +45,7 @@ We regularly update this FAQ based on community feedback and network development
     lastUpdated="2025-01-25"
   >
     <ContentText>
-      Network stats are available at the top of the <Link to="https://astral.autonomys.xyz/">Astral Block Explorer</Link>.
+      Network stats are available at the top of the <Link to="https://autonomys.subscan.io">Subscan Block Explorer</Link>.
     </ContentText>
   </ContentBlock>
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -237,8 +237,8 @@ const config = {
             position: 'left',
             items: [
               {
-                label: 'Astral Block Explorer',
-                href: 'https://astral.autonomys.xyz',
+                label: 'Subscan Block Explorer',
+                href: 'https://autonomys.subscan.io',
               },
               {
                 label: 'PolkadotJS Portal',

--- a/src/theme/Footer/index.js
+++ b/src/theme/Footer/index.js
@@ -54,7 +54,7 @@ export default function FooterWrapper(props) {
                 </li>
                 <li>
                   <FooterLink 
-                    href="https://astral.autonomys.xyz" 
+                    href="https://autonomys.subscan.io" 
                     label="Block Explorer" 
                     icon={ICONS.EXPLORER}
                   />


### PR DESCRIPTION
Replace Astral Explorer references with Subscan Explorer. The XDM documentation will be updated in a different PR.