### PR TITLE
Add placeholder page for operator registration with current status

### DIFF
--- a/docs/farming-&-staking/staking/operators/register.mdx
+++ b/docs/farming-&-staking/staking/operators/register.mdx
@@ -1,0 +1,11 @@
+---
+title: Become an Operator
+sidebar_position: 1
+slug: /staking/operator/register
+---
+
+# Become an Operator
+
+Operators are currently only available on Mainnet in a permissioned capacity, run by the Subspace Foundation.
+
+Permissionless operators will first be tested on Chronos testnet before being enabled on Mainnet. This page will be updated as progress is made on both networks.


### PR DESCRIPTION
Resolves #915 by adding a placeholder page at /staking/operator/register explaining that operators are currently permissioned on Mainnet and will be tested on Chronos testnet before public availability.