### PR TITLE
Update polkadot-apps.mdx

### DIFF
--- a/docs/farming-&-staking/staking/additional-guides/polkadot-apps.mdx
+++ b/docs/farming-&-staking/staking/additional-guides/polkadot-apps.mdx
@@ -106,7 +106,7 @@ It will take **14,400 domain blocks** from a successful withdrawal before you ca
 <ContentListItem>Select the wallet you'd like to use (if you have more than one).</ContentListItem>
 <ContentListItem>Choose `domains`.</ContentListItem>
 <ContentListItem>Select `unlockNominator`.</ContentListItem>
-<ContentListItem>Enter the `OperatorId` you wish to Unlock.</ContentListItem>
+<ContentListItem>Enter the `OperatorId` you wish to unlock.</ContentListItem>
 <ContentListItem>Click `Submit Transaction` and sign the extrinsic with your supported <Link to="/wallets">wallet</Link>.</ContentListItem>
 </ContentList>
 </ContentBlock>


### PR DESCRIPTION
The text sections for "withdrawing funds" and "unlockNominator" are mistakenly identified as "wish to nominate".