### PR TITLE
docs: fixed invalid Discord invite link in connectivity-troubleshooting

### DIFF
--- a/docs/networking/connectivity-issues.mdx
+++ b/docs/networking/connectivity-issues.mdx
@@ -395,7 +395,7 @@ grep -i "peers" /path/to/node.log | tail -20 >> debug.log
 
 ### Where to Get Help
 
-1. **Discord**: [Autonomys Discord](https://discord.gg/autonomys)
+1. **Discord**: [Autonomys Discord](https://discord.gg/subspace-network)
    - #farming-support channel
    - Include debug.log contents
 

--- a/docs/networking/connectivity-issues.mdx
+++ b/docs/networking/connectivity-issues.mdx
@@ -395,7 +395,7 @@ grep -i "peers" /path/to/node.log | tail -20 >> debug.log
 
 ### Where to Get Help
 
-1. **Discord**: [Autonomys Discord](https://discord.gg/subspace-network)
+1. **Discord**: [Autonomys Discord](https://autonomys.xyz/discord)
    - #farming-support channel
    - Include debug.log contents
 


### PR DESCRIPTION
## Description
During a technical review of the documentation, I identified that the Discord invite link was returning an "Invalid Invite" error, causing friction for new node operators attempting to access support.

## Changes
* **Discord**: Updated the broken invite link to the current active one (`https://discord.gg/autonomys`).

## Impact
Ensures that users seeking assistance with connectivity issues can successfully reach the official #farming-support channel.