### PR TITLE
docs: update bridge guide for Ethereum, BNB Chain, and Solana

### DIFF
--- a/docs/ai3_token/bridge/inbound.mdx
+++ b/docs/ai3_token/bridge/inbound.mdx
@@ -1,18 +1,22 @@
 ---
 title: Inbound Bridge
 sidebar_position: 3
-description: Learn how to bridge WAI3 tokens to Auto EVM
+description: Learn how to bridge tokens to Auto EVM from Ethereum, BNB Chain, or Solana
 slug: /bridge/inbound
 keywords:
     - Bridge
     - EVM
     - Transfer
+    - Ethereum
+    - BNB Chain
+    - BSC
+    - Solana
 ---
 
-## Sending WAI3 to Auto EVM
+## Sending Tokens to Auto EVM
 
 :::note
-You will need ETH on your sending wallet to pay for the bridging transaction.
+You will need the native gas token of your source network on your sending wallet to pay for the bridging transaction - **ETH** when bridging from Ethereum, **BNB** when bridging from BNB Chain, or **SOL** when bridging from Solana.
 :::
 
 1. First, make sure that you have set the from and to networks, the token and the amount you want to bridge.
@@ -27,7 +31,7 @@ You will need ETH on your sending wallet to pay for the bridging transaction.
 
 ![Bridge](/img/doc-imgs/additional-guides/bridge-25.jpeg)
 
-4. Confirm the transaction in Metamask.
+4. Confirm the transaction in your wallet (Metamask for Ethereum/BNB Chain, or your Solana wallet for Solana).
 
 ![Bridge](/img/doc-imgs/additional-guides/bridge-26.jpeg)
 

--- a/docs/ai3_token/bridge/intro.mdx
+++ b/docs/ai3_token/bridge/intro.mdx
@@ -44,7 +44,7 @@ When adding bridged tokens to your wallet, use the following contract addresses:
 :::note Mainnet and Testnet
 [Mainnet Bridge](https://bridge.mainnet.autonomys.xyz/)
 
-[Chronos Testnet Bridge](https://bridge.chronos.autonomys.xyz/) - use this to try bridging with testnet tokens. To get tAI3 testnet tokens, use the [official web-based faucet](https://autonomysfaucet.xyz/) or request them via the `/faucet` slash command in the [#faucet channel on Discord](https://discord.gg/autonomys). Tokens can be requested once every 24 hours. See the [full faucet guide](https://develop.autonomys.xyz/evm/faucet) for details.
+[Chronos Testnet Bridge](https://bridge.chronos.autonomys.xyz/) - use this to try bridging with testnet tokens. To get tAI3 testnet tokens, use the [official web-based faucet](https://autonomysfaucet.xyz/) or request them via the `/faucet` slash command in the [#faucet channel on Discord](https://autonomys.xyz/discord). Tokens can be requested once every 24 hours. See the [full faucet guide](https://develop.autonomys.xyz/evm/faucet) for details.
 :::
 
 1. Navigate to the [Mainnet Bridge Site](https://bridge.mainnet.autonomys.xyz/).

--- a/docs/ai3_token/bridge/intro.mdx
+++ b/docs/ai3_token/bridge/intro.mdx
@@ -15,16 +15,36 @@ import Link from '@docusaurus/Link';
 
 This guide explains how to bridge tokens between Auto EVM and other networks.
 
+### Supported Networks
+
+The Autonomys bridge currently supports the following external networks:
+
+| Network | Status |
+|---------|--------|
+| Ethereum | Live |
+| BNB Chain | Live |
+| Solana | Live |
+
 :::tip
-In this example we will be bridging back and forth between Auto EVM and Ethereum on mainnet, but BNB Chain is also supported.
+The step-by-step examples in this guide use Ethereum, but the same flow applies to BNB Chain and Solana. Select your preferred network in the bridge UI when choosing the source or destination.
 :::
+
+### Token Contract Addresses
+
+When adding bridged tokens to your wallet, use the following contract addresses:
+
+| Network | Token | Contract Address |
+|---------|-------|-----------------|
+| Ethereum | WAI3 | [0x363FCa95F23E10C76ef793D62d92d39e89d83AC1](https://etherscan.io/address/0x363FCa95F23E10C76ef793D62d92d39e89d83AC1) |
+| BNB Chain | WAI3 | [0x220375118d0600a8fce7bf1aad5fcf2ae6ed069b](https://bscscan.com/token/0x220375118d0600a8fce7bf1aad5fcf2ae6ed069b) |
+| Solana | AI3 | [veS2vDmcRY1Bd1zsC1TLiG85rXSwz119UCZAvNZBt7n](https://solscan.io/token/veS2vDmcRY1Bd1zsC1TLiG85rXSwz119UCZAvNZBt7n) |
 
 ### Connecting a wallet to the Bridge
 
-:::note supported Networks
+:::note Mainnet and Testnet
 [Mainnet Bridge](https://bridge.mainnet.autonomys.xyz/)
 
-[Chronos Testnet Bridge](https://bridge.chronos.autonomys.xyz/)
+[Chronos Testnet Bridge](https://bridge.chronos.autonomys.xyz/) - use this to try bridging with testnet tokens. To get tAI3 testnet tokens, use the [official web-based faucet](https://autonomysfaucet.xyz/) or request them via the `/faucet` slash command in the [#faucet channel on Discord](https://discord.gg/autonomys). Tokens can be requested once every 24 hours. See the [full faucet guide](https://develop.autonomys.xyz/evm/faucet) for details.
 :::
 
 1. Navigate to the [Mainnet Bridge Site](https://bridge.mainnet.autonomys.xyz/).
@@ -49,12 +69,12 @@ In this example we will be bridging back and forth between Auto EVM and Ethereum
 
 ## Bridging Options
 
-For information on sending AI3 to Ethereum, refer to the <Link to="/bridge/outbound">Outbound Bridge</Link> guide.
+For information on sending AI3 from Auto EVM to an external network (Ethereum, BNB Chain, or Solana), refer to the <Link to="/bridge/outbound">Outbound Bridge</Link> guide.
 
-For information on sending WAI3 to Auto EVM, refer to the <Link to="/bridge/inbound">Inbound Bridge</Link> guide.
+For information on sending tokens from an external network to Auto EVM, refer to the <Link to="/bridge/inbound">Inbound Bridge</Link> guide.
 
 ## Viewing Bridge Transactions
 
-Clicking on the account lozenge in the top right will give you a list of historical bridge transactions where you can inspect previous transfers.
+Click the clock icon to view a list of historical bridge transactions and inspect previous transfers. The arrows on the left edge of the slide-out close it.
 
 ![Bridge](/img/doc-imgs/additional-guides/bridge-29.jpeg)

--- a/docs/ai3_token/bridge/outbound.mdx
+++ b/docs/ai3_token/bridge/outbound.mdx
@@ -1,15 +1,23 @@
 ---
 title: Outbound Bridge
 sidebar_position: 2
-description: Learn how to bridge AI3 tokens to Ethereum
+description: Learn how to bridge AI3 tokens to Ethereum, BNB Chain, or Solana
 slug: /bridge/outbound
 keywords:
     - Bridge
     - EVM
     - Transfer
+    - Ethereum
+    - BNB Chain
+    - BSC
+    - Solana
 ---
 
-## Sending AI3 to Ethereum
+## Sending AI3 to an External Network
+
+:::tip
+The screenshots below show bridging to Ethereum, but the same steps apply when bridging to **BNB Chain** or **Solana** - simply select your preferred destination network in the bridge UI.
+:::
 
 1. Select the AI3 token and enter the amount you want to transfer.
 
@@ -55,7 +63,9 @@ keywords:
 
 ![Bridge](/img/doc-imgs/additional-guides/bridge-17.jpeg)
 
-## Adding WAI3 on Ethereum to Metamask
+## Adding Bridged Tokens to Your Wallet
+
+### Ethereum
 
 1. To view your bridged AI3 on Ethereum you will need to add the token to Metamask. The Ethereum WAI3 contract can be found at [0x363FCa95F23E10C76ef793D62d92d39e89d83AC1](https://etherscan.io/address/0x363FCa95F23E10C76ef793D62d92d39e89d83AC1) which will need importing.
 
@@ -78,3 +88,17 @@ keywords:
 6. The token and your balance now appears.
 
 ![Bridge](/img/doc-imgs/additional-guides/bridge-22.png)
+
+### BNB Chain
+
+1. To view your bridged AI3 on BNB Chain you will need to add the token to Metamask. The BNB Chain WAI3 contract can be found at [0x220375118d0600a8fce7bf1aad5fcf2ae6ed069b](https://bscscan.com/token/0x220375118d0600a8fce7bf1aad5fcf2ae6ed069b) which will need importing.
+
+2. Switch network in Metamask to BNB Chain, then follow the same steps as Ethereum above: go to the Tokens tab, click the hamburger button, click `Import Tokens`, switch to the Custom token tab, and enter the contract address `0x220375118d0600a8fce7bf1aad5fcf2ae6ed069b`. The symbol and decimals will auto-populate.
+
+### Solana
+
+On Solana, the bridged token is **AI3** (not WAI3). You will need a Solana-compatible wallet such as [Phantom](https://phantom.app/) or [Solflare](https://solflare.com/).
+
+1. To view your bridged AI3 on Solana, open your Solana wallet and add the token using the contract address [`veS2vDmcRY1Bd1zsC1TLiG85rXSwz119UCZAvNZBt7n`](https://solscan.io/token/veS2vDmcRY1Bd1zsC1TLiG85rXSwz119UCZAvNZBt7n).
+
+2. In Phantom, go to the tokens list, click `+`, and paste the contract address. The token name and symbol will auto-populate.


### PR DESCRIPTION
## Summary

- Adds a **Supported Networks** table to the bridge overview listing Ethereum, BNB Chain, and Solana (all live)
- Adds a **Token Contract Addresses** table with links to Etherscan, BscScan, and Solscan
- Expands the **Outbound Bridge** guide with wallet token import instructions for BNB Chain (WAI3) and Solana (AI3), and notes that Solana uses Phantom/Solflare rather than Metamask
- Updates the **Inbound Bridge** guide heading and gas token note to cover ETH, BNB, and SOL
- Updates "Viewing Bridge Transactions" to reference the clock icon (replacing the old account lozenge reference)
- Adds Chronos testnet bridge link with faucet details (web faucet + Discord)
- Adds Solana to keywords/description frontmatter across all three pages

## Test plan

- [x] Verify contract address links resolve correctly (Etherscan, BscScan, Solscan)
- [x] Verify faucet links are live

Made with [Cursor](https://cursor.com)