### PR TITLE
Allow manual triggering of build-and-deploy workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,5 @@
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'
   push:


### PR DESCRIPTION
Add workflow_dispatch trigger so the workflow can be run on demand from the GitHub Actions UI.