### PR TITLE
Update mainnet-2026-mar-09 -> mainnet-2026-jun-08

### DIFF
--- a/docs/farming/additional-guides/cli-node-types.mdx
+++ b/docs/farming/additional-guides/cli-node-types.mdx
@@ -25,7 +25,7 @@ This is the most common type of node as it is used by farmers. It processes all 
 :::
 
 ```bash
-./subspace-node-ubuntu-x86_64-skylake-mainnet-2026-mar-09 run \
+./subspace-node-ubuntu-x86_64-skylake-mainnet-2026-jun-08 run \
 --chain mainnet \
 --base-path "<BASE_PATH>"
 ```
@@ -43,7 +43,7 @@ An archival node keeps a history of all blocks and serves peers. It preserves th
 :::
 
 ```bash
-./subspace-node-ubuntu-x86_64-skylake-mainnet-2026-mar-09 run \
+./subspace-node-ubuntu-x86_64-skylake-mainnet-2026-jun-08 run \
 --chain mainnet \
 --base-path "<BASE_PATH>" \
 --blocks-pruning archive \
@@ -64,7 +64,7 @@ Timekeepers run the Proof-of-Time chain and maintain the randomness beacon for t
 :::
 
 ```bash
-./subspace-node-ubuntu-x86_64-skylake-mainnet-2026-mar-09 run \
+./subspace-node-ubuntu-x86_64-skylake-mainnet-2026-jun-08 run \
 --chain mainnet \
 --timekeeper \
 --timekeeper-cpu-cores 4 \ 

--- a/docs/farming/cli/cli-farming-cluster.mdx
+++ b/docs/farming/cli/cli-farming-cluster.mdx
@@ -126,7 +126,7 @@ Refer to our guide on [Port Forwarding](/farming/guides/port-config).
 :::
 
 ```bash
-./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-mar-09 \
+./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-jun-08 \
     cluster \
         --nats-server "nats://<NATS_IP>:4222" \
     controller \
@@ -173,7 +173,7 @@ The current Archive History Size can be found in the top cards on [Subscan Block
 :::
 
 ```bash
-./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-mar-09 \
+./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-jun-08 \
     cluster \
         --nats-server "nats://<NATS_IP>:4222" \
     cache \
@@ -212,7 +212,7 @@ Refer to `./subspace-farmer cluster cache --help` for an explanation of addition
 :::
 
 ```bash
-./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-mar-09 \
+./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-jun-08 \
     cluster \
         --nats-server "nats://<NATS_IP>:4222" \
     plotter
@@ -240,7 +240,7 @@ Refer to `./subspace-farmer cluster plotter --help` for an explanation of parame
 :::
 
 ```bash
-./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-mar-09 \
+./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-jun-08 \
     cluster \
         --nats-server "nats://<NATS_IP>:4222" \
     farmer \
@@ -276,7 +276,7 @@ Refer to `./subspace-farmer cluster farmer --help` for an explanation of each op
 <summary>You can run Farming Cluster components individually or combine them to run simultaneously.</summary>
 
 ```bash
-./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-mar-09 \
+./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-jun-08 \
     cluster \
         --nats-server "nats://<NATS_IP>:4222" \
     controller \
@@ -322,7 +322,7 @@ flowchart
 <summary>Configuration</summary>
 
 ```bash
-./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-mar-09 cluster \
+./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-jun-08 cluster \
     controller \
         --nats-server="nats://<NATS_IP_1>:4222" \
         --nats-server="nats://<NATS_IP_2>:4222" \
@@ -382,7 +382,7 @@ Each cache group must have a unique name, and controllers can be assigned one or
 <summary>Configuration</summary>
 
 ```bash title="Controller #1"
-./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-mar-09 \
+./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-jun-08 \
     cluster \
         --nats-server "nats://<NATS_IP>:4222" \
     controller \
@@ -393,7 +393,7 @@ Each cache group must have a unique name, and controllers can be assigned one or
 ```
 
 ```bash title="Controller #2"
-./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-mar-09 \
+./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-jun-08 \
     cluster \
         --nats-server "nats://<NATS_IP>:4222" \
     controller \
@@ -403,7 +403,7 @@ Each cache group must have a unique name, and controllers can be assigned one or
 ```
 
 ```bash title="Cache #1"
-./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-mar-09 \
+./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-jun-08 \
     cluster \
         --nats-server "nats://<NATS_IP>:4222" \
     cache \
@@ -412,7 +412,7 @@ Each cache group must have a unique name, and controllers can be assigned one or
 ```
 
 ```bash title="Cache #2"
-./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-mar-09 \
+./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-jun-08 \
     cluster \
         --nats-server "nats://<NATS_IP>:4222" \
     cache \
@@ -421,21 +421,21 @@ Each cache group must have a unique name, and controllers can be assigned one or
 ```
 
 ```bash title="Plotter #1"
-./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-mar-09 \
+./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-jun-08 \
     cluster \
         --nats-server "nats://<NATS_IP>:4222" \
     plotter
 ```
 
 ```bash title="Plotter #2"
-./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-mar-09 \
+./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-jun-08 \
     cluster \
         --nats-server "nats://<NATS_IP>:4222" \
     plotter
 ```
 
 ```bash title="Farmer #1"
-./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-mar-09 \
+./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-jun-08 \
     cluster \
         --nats-server "nats://<NATS_IP>:4222" \
     farmer \
@@ -444,7 +444,7 @@ Each cache group must have a unique name, and controllers can be assigned one or
 ```
 
 ```bash title="Farmer #2"
-./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-mar-09 \
+./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-jun-08 \
     cluster \
         --nats-server "nats://<NATS_IP>:4222" \
     farmer \
@@ -453,7 +453,7 @@ Each cache group must have a unique name, and controllers can be assigned one or
 ```
 
 ```bash title="Farmer #3"
-./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-mar-09 \
+./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-jun-08 \
     cluster \
         --nats-server "nats://<NATS_IP>:4222" \
     farmer \

--- a/docs/farming/cli/cli-tips.mdx
+++ b/docs/farming/cli/cli-tips.mdx
@@ -40,8 +40,8 @@ If you were running a node previously, and want to switch to a new network, plea
 :::
 
 ```bash
-./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-mar-09 wipe <PATH_TO_FARM>
-./subspace-node-ubuntu-x86_64-skylake-mainnet-2026-mar-09 wipe <BASE_PATH>
+./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-jun-08 wipe <PATH_TO_FARM>
+./subspace-node-ubuntu-x86_64-skylake-mainnet-2026-jun-08 wipe <BASE_PATH>
 ```
 
 Now follow the installation guide from the beginning.
@@ -55,7 +55,7 @@ To maximize storage capabilities, you can engage multiple disks directly. This i
 :::
 
 ```bash
-./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-mar-09 farm --reward-address "<REWARD_ADDRESS>" \
+./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-jun-08 farm --reward-address "<REWARD_ADDRESS>" \
     path="/media/ssd1,size=4TiB" \
     path="/media/ssd2,size=8TiB"
 ```
@@ -136,7 +136,7 @@ For example, you can include record-chunks-mode= after defining the path and siz
 Benchmarking helps you test the plotting speed of your farmer against different versions of the Autonomys Network.
 
 ```
-./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-mar-09 benchmark audit <PATH_TO_FARM>
+./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-jun-08 benchmark audit <PATH_TO_FARM>
 ```
 
 :::tip
@@ -154,7 +154,7 @@ To read more about audit benchmarking, [read this forum post](https://forum.auto
 There is a second command available, which helps you determine how much time your farmer has after auditing to provide proof.
 
 ```
-./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-mar-09 benchmark prove <PATH_TO_FARM>
+./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-jun-08 benchmark prove <PATH_TO_FARM>
 ```
 
 Each farmer has ~4 seconds to audit and prove, so depending on how fast auditing is, the remaining time will be used for proving.
@@ -170,7 +170,7 @@ To read more about prove benchmarking, [read this forum post](https://forum.auto
 In certain situations, especially when the farmer terminates unexpectedly or encounters an error, it might fail to restart correctly. The scrub command assists in resolving such issues by cleaning or resetting the specified farm.
 
 ```
-./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-mar-09 scrub <PATH_TO_FARM>
+./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-jun-08 scrub <PATH_TO_FARM>
 ```
 
 :::tip

--- a/docs/farming/cli/platforms/_linux.mdx
+++ b/docs/farming/cli/platforms/_linux.mdx
@@ -6,33 +6,33 @@ import ReleaseContainer from '@site/src/components/ReleaseContainer';
 
 <ReleaseContainer>
   <ReleaseButton
-    to="https://github.com/autonomys/subspace/releases/download/mainnet-2026-mar-09/subspace-node-ubuntu-x86_64-skylake-mainnet-2026-mar-09"
+    to="https://github.com/autonomys/subspace/releases/download/mainnet-2026-jun-08/subspace-node-ubuntu-x86_64-skylake-mainnet-2026-jun-08"
     title="Node Executable"
     subtitle="(Skylake+ CPU)" />
   <ReleaseButton
-    to="https://github.com/autonomys/subspace/releases/download/mainnet-2026-mar-09/subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-mar-09"
+    to="https://github.com/autonomys/subspace/releases/download/mainnet-2026-jun-08/subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-jun-08"
     title="Farmer Executable"
     subtitle="(Skylake+ CPU)" />
 </ReleaseContainer>
 
 <ReleaseContainer>
   <ReleaseButton
-    to="https://github.com/autonomys/subspace/releases/download/mainnet-2026-mar-09/subspace-node-ubuntu-x86_64-v2-mainnet-2026-mar-09"
+    to="https://github.com/autonomys/subspace/releases/download/mainnet-2026-jun-08/subspace-node-ubuntu-x86_64-v2-mainnet-2026-jun-08"
     title="Node Executable"
     subtitle="(Legacy CPU)" />
   <ReleaseButton
-    to="https://github.com/autonomys/subspace/releases/download/mainnet-2026-mar-09/subspace-farmer-ubuntu-x86_64-v2-mainnet-2026-mar-09"
+    to="https://github.com/autonomys/subspace/releases/download/mainnet-2026-jun-08/subspace-farmer-ubuntu-x86_64-v2-mainnet-2026-jun-08"
     title="Farmer Executable"
     subtitle="(Legacy CPU)" />
 </ReleaseContainer>
 
 <ReleaseContainer>
   <ReleaseButton
-    to="https://github.com/autonomys/subspace/releases/download/mainnet-2026-mar-09/subspace-node-ubuntu-aarch64-mainnet-2026-mar-09"
+    to="https://github.com/autonomys/subspace/releases/download/mainnet-2026-jun-08/subspace-node-ubuntu-aarch64-mainnet-2026-jun-08"
     title="Node Executable"
     subtitle="(Aarch64/Raspberry Pi)" />
   <ReleaseButton
-    to="https://github.com/autonomys/subspace/releases/download/mainnet-2026-mar-09/subspace-farmer-ubuntu-aarch64-mainnet-2026-mar-09"
+    to="https://github.com/autonomys/subspace/releases/download/mainnet-2026-jun-08/subspace-farmer-ubuntu-aarch64-mainnet-2026-jun-08"
     title="Farmer Executable"
     subtitle="(Aarch64/Raspberry Pi)" />
 </ReleaseContainer>
@@ -49,8 +49,8 @@ cd ~/Downloads
 2. Make the `farmer` and `node` executable:
 
 ```bash
-chmod +x subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-mar-09
-chmod +x subspace-node-ubuntu-x86_64-skylake-mainnet-2026-mar-09
+chmod +x subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-jun-08
+chmod +x subspace-node-ubuntu-x86_64-skylake-mainnet-2026-jun-08
 ```
 
 3. Start the node using the command below. Ensure you copy the entire command:
@@ -63,7 +63,7 @@ chmod +x subspace-node-ubuntu-x86_64-skylake-mainnet-2026-mar-09
 :::
 
 ```bash
-./subspace-node-ubuntu-x86_64-skylake-mainnet-2026-mar-09 \
+./subspace-node-ubuntu-x86_64-skylake-mainnet-2026-jun-08 \
   run \
   --chain mainnet \
   --base-path "<BASE_PATH>" \
@@ -135,7 +135,7 @@ Reserve at least 100GiB for the node and additional space for your operating sys
 :::
 
 ```bash
-./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-mar-09 farm \
+./subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-jun-08 farm \
   --reward-address "<REWARD_ADDRESS>" \
   path="<PATH_TO_FARM>,size=<FARM_SIZE>"
 ```

--- a/docs/farming/cli/platforms/_macos.mdx
+++ b/docs/farming/cli/platforms/_macos.mdx
@@ -13,11 +13,11 @@ The minimum support macOS version is version 12+
  
 <ReleaseContainer>
   <ReleaseButton 
-    to="https://github.com/autonomys/subspace/releases/download/mainnet-2026-mar-09/subspace-node-macos-aarch64-mainnet-2026-mar-09.zip" 
+    to="https://github.com/autonomys/subspace/releases/download/mainnet-2026-jun-08/subspace-node-macos-aarch64-mainnet-2026-jun-08.zip" 
     title="Node Executable" 
     subtitle="(Apple CPU)" />
   <ReleaseButton 
-    to="https://github.com/autonomys/subspace/releases/download/mainnet-2026-mar-09/subspace-farmer-macos-aarch64-mainnet-2026-mar-09.zip" 
+    to="https://github.com/autonomys/subspace/releases/download/mainnet-2026-jun-08/subspace-farmer-macos-aarch64-mainnet-2026-jun-08.zip" 
     title="Farmer Executable" 
     subtitle="(Apple CPU)" />
 </ReleaseContainer>
@@ -37,8 +37,8 @@ After this, simply repeat the step you prompted for. This time, click the `Open`
 
 2. Make the farmer & node executable:
 
-- `chmod +x subspace-farmer-macos-aarch64-mainnet-2026-mar-09`
-- `chmod +x subspace-node-macos-aarch64-mainnet-2026-mar-09`
+- `chmod +x subspace-farmer-macos-aarch64-mainnet-2026-jun-08`
+- `chmod +x subspace-node-macos-aarch64-mainnet-2026-jun-08`
 
 3. Start the node using the command below. Ensure you copy the entire command:
 
@@ -50,7 +50,7 @@ After this, simply repeat the step you prompted for. This time, click the `Open`
 :::
 
 ```bash
-./subspace-node-macos-aarch64-mainnet-2026-mar-09 \
+./subspace-node-macos-aarch64-mainnet-2026-jun-08 \
   run \
   --chain mainnet \
   --base-path "<BASE_PATH>" \
@@ -103,7 +103,7 @@ Reserve at least 100GiB for the node and additional space for your operating sys
 :::
 
 ```bash
-./subspace-farmer-macos-aarch64-mainnet-2026-mar-09 farm --reward-address \"<REWARD_ADDRESS>\" path=\"<PATH_TO_FARM>,size=<FARM_SIZE>\"
+./subspace-farmer-macos-aarch64-mainnet-2026-jun-08 farm --reward-address \"<REWARD_ADDRESS>\" path=\"<PATH_TO_FARM>,size=<FARM_SIZE>\"
 ```
 
 2. You should see output similar to this in your terminal:

--- a/docs/farming/cli/platforms/_source.mdx
+++ b/docs/farming/cli/platforms/_source.mdx
@@ -19,11 +19,11 @@ You'll have to have [Rust toolchain](https://rustup.rs/) installed as well as LL
 sudo apt-get install llvm clang cmake
 ```
 
-Now clone the source and build snapshot `mainnet-2026-mar-09` (replace occurrences with the snapshot you want to build):
+Now clone the source and build snapshot `mainnet-2026-jun-08` (replace occurrences with the snapshot you want to build):
 ```bash
 git clone https://github.com/autonomys/subspace.git
 cd subspace
-git checkout mainnet-2026-mar-09
+git checkout mainnet-2026-jun-08
 cargo build \
     --profile production \
     --bin subspace-node \

--- a/docs/farming/cli/platforms/_systemd.mdx
+++ b/docs/farming/cli/platforms/_systemd.mdx
@@ -41,11 +41,11 @@ Download the Executable Files, using the appropriate commands:
         </summary>
 		Node:
 		```bash
-		wget -O ~/.local/bin/subspace-node https://github.com/autonomys/subspace/releases/download/mainnet-2026-mar-09/subspace-node-ubuntu-x86_64-v2-mainnet-2026-mar-09
+		wget -O ~/.local/bin/subspace-node https://github.com/autonomys/subspace/releases/download/mainnet-2026-jun-08/subspace-node-ubuntu-x86_64-v2-mainnet-2026-jun-08
 		```
 		Farmer:
 		```bash
-		wget -O ~/.local/bin/subspace-farmer https://github.com/autonomys/subspace/releases/download/mainnet-2026-mar-09/subspace-farmer-ubuntu-x86_64-v2-mainnet-2026-mar-09
+		wget -O ~/.local/bin/subspace-farmer https://github.com/autonomys/subspace/releases/download/mainnet-2026-jun-08/subspace-farmer-ubuntu-x86_64-v2-mainnet-2026-jun-08
 		```
     </details>
     <details>
@@ -54,11 +54,11 @@ Download the Executable Files, using the appropriate commands:
         </summary>
 		Node:
 		```bash
-		wget -O ~/.local/bin/subspace-node https://github.com/autonomys/subspace/releases/download/mainnet-2026-mar-09/subspace-node-ubuntu-x86_64-skylake-mainnet-2026-mar-09
+		wget -O ~/.local/bin/subspace-node https://github.com/autonomys/subspace/releases/download/mainnet-2026-jun-08/subspace-node-ubuntu-x86_64-skylake-mainnet-2026-jun-08
 		```
 		Farmer:
 		```bash
-		wget -O ~/.local/bin/subspace-farmer https://github.com/autonomys/subspace/releases/download/mainnet-2026-mar-09/subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-mar-09
+		wget -O ~/.local/bin/subspace-farmer https://github.com/autonomys/subspace/releases/download/mainnet-2026-jun-08/subspace-farmer-ubuntu-x86_64-skylake-mainnet-2026-jun-08
 		```
     </details>
 </details>
@@ -69,11 +69,11 @@ Download the Executable Files, using the appropriate commands:
     </summary>
 	Node:
 	```bash
-	wget -O ~/.local/bin/subspace-node https://github.com/autonomys/subspace/releases/download/mainnet-2026-mar-09/subspace-node-ubuntu-aarch64-mainnet-2026-mar-09
+	wget -O ~/.local/bin/subspace-node https://github.com/autonomys/subspace/releases/download/mainnet-2026-jun-08/subspace-node-ubuntu-aarch64-mainnet-2026-jun-08
 	```
 	Farmer:
 	```bash
-	wget -O ~/.local/bin/subspace-farmer https://github.com/autonomys/subspace/releases/download/mainnet-2026-mar-09/subspace-farmer-ubuntu-aarch64-mainnet-2026-mar-09
+	wget -O ~/.local/bin/subspace-farmer https://github.com/autonomys/subspace/releases/download/mainnet-2026-jun-08/subspace-farmer-ubuntu-aarch64-mainnet-2026-jun-08
 	```
 </details>
 

--- a/docs/farming/cli/platforms/_windows.mdx
+++ b/docs/farming/cli/platforms/_windows.mdx
@@ -13,22 +13,22 @@ If you face an error where the node outputs nothing and no error code is given i
 
 <ReleaseContainer>
   <ReleaseButton 
-    to="https://github.com/autonomys/subspace/releases/download/mainnet-2026-mar-09/subspace-node-windows-x86_64-skylake-mainnet-2026-mar-09.exe" 
+    to="https://github.com/autonomys/subspace/releases/download/mainnet-2026-jun-08/subspace-node-windows-x86_64-skylake-mainnet-2026-jun-08.exe" 
     title="Node Executable" 
     subtitle="(Skylake+ CPU)" />
   <ReleaseButton 
-    to="https://github.com/autonomys/subspace/releases/download/mainnet-2026-mar-09/subspace-farmer-windows-x86_64-skylake-mainnet-2026-mar-09.exe" 
+    to="https://github.com/autonomys/subspace/releases/download/mainnet-2026-jun-08/subspace-farmer-windows-x86_64-skylake-mainnet-2026-jun-08.exe" 
     title="Farmer Executable" 
     subtitle="(Skylake+ CPU)" />
 </ReleaseContainer>
  
 <ReleaseContainer>
   <ReleaseButton 
-    to="https://github.com/autonomys/subspace/releases/download/mainnet-2026-mar-09/subspace-node-windows-x86_64-v2-mainnet-2026-mar-09.exe" 
+    to="https://github.com/autonomys/subspace/releases/download/mainnet-2026-jun-08/subspace-node-windows-x86_64-v2-mainnet-2026-jun-08.exe" 
     title="Node Executable" 
     subtitle="(Legacy CPU)" />
   <ReleaseButton 
-    to="https://github.com/autonomys/subspace/releases/download/mainnet-2026-mar-09/subspace-farmer-windows-x86_64-v2-mainnet-2026-mar-09.exe" 
+    to="https://github.com/autonomys/subspace/releases/download/mainnet-2026-jun-08/subspace-farmer-windows-x86_64-v2-mainnet-2026-jun-08.exe" 
     title="Farmer Executable" 
     subtitle="(Legacy CPU)" />
 </ReleaseContainer>
@@ -58,7 +58,7 @@ This is because the application is trying to access the internet. This is expect
 :::
 
 ```powershell
-.\subspace-node-windows-x86_64-skylake-mainnet-2026-mar-09.exe `
+.\subspace-node-windows-x86_64-skylake-mainnet-2026-jun-08.exe `
   run `
   --chain mainnet `
   --base-path "<BASE_PATH>" `
@@ -119,7 +119,7 @@ Reserve at least 100GiB for the node and additional space for your operating sys
 :::
 
 ```PowerShell
-.\subspace-farmer-windows-x86_64-skylake-mainnet-2026-mar-09.exe farm --reward-address "<REWARD_ADDRESS>" path="<PATH_TO_FARM>,size=<FARM_SIZE>"
+.\subspace-farmer-windows-x86_64-skylake-mainnet-2026-jun-08.exe farm --reward-address "<REWARD_ADDRESS>" path="<PATH_TO_FARM>,size=<FARM_SIZE>"
 ```
 
 2. You should see output similar to this in your terminal:

--- a/docs/staking/additional-guides/domains-node-types.mdx
+++ b/docs/staking/additional-guides/domains-node-types.mdx
@@ -31,7 +31,7 @@ A domain full node processes all blocks and serves peers. It preserves the block
 :::
 
 ```bash
-./subspace-node-ubuntu-x86_64-skylake-mainnet-2026-mar-09 run \
+./subspace-node-ubuntu-x86_64-skylake-mainnet-2026-jun-08 run \
 --chain mainnet \
 --base-path "<BASE_PATH>" \
 --blocks-pruning archive \
@@ -54,7 +54,7 @@ By default the RPC port is 9944 so you can leave the `rpc-listen-on` out. If you
 :::
 
 ```bash
-./subspace-node-ubuntu-x86_64-skylake-mainnet-2026-mar-09 run \
+./subspace-node-ubuntu-x86_64-skylake-mainnet-2026-jun-08 run \
 --chain mainnet \
 --base-path "<BASE_PATH>" \
 --blocks-pruning archive \
@@ -83,7 +83,7 @@ An operator node is closer to an *archive domain node* rather than a *full domai
 :::
 
 ```bash
-./subspace-node-ubuntu-x86_64-skylake-mainnet-2026-mar-09 run \
+./subspace-node-ubuntu-x86_64-skylake-mainnet-2026-jun-08 run \
 --chain chronos \
 --name "<NAME>" \
 --base-path "<BASE_PATH>" \


### PR DESCRIPTION
In line with release of https://github.com/autonomys/subspace/releases/tag/mainnet-2026-jun-08.