### PR TITLE
docs: update XDM tool link to subspace.tools

### DIFF
--- a/docs/ai3_token/cross-domain-messaging.mdx
+++ b/docs/ai3_token/cross-domain-messaging.mdx
@@ -103,4 +103,4 @@ It is possible to use the [Auto SDK](https://develop.autonomys.xyz/sdk/auto-xdm)
 
 ## Tracking XDM Transfers
 
-A community maintained XDM Transfer Status Tool has been deployed at https://autonomys-community.github.io/autonomys-helpers/xdm/transfers/ and allows you to search for details and progress of XDM activity. Contributions are very welcome.
+A community maintained XDM Transfer Status tool, part of [Subspace Tools](https://subspace.tools), has been deployed at https://subspace.tools/xdm/transfers/ and allows you to search for details and progress of XDM activity. Contributions are very welcome.


### PR DESCRIPTION
The community-maintained XDM Transfer Status tool has moved from `autonomys-community.github.io/autonomys-helpers` to https://subspace.tools as part of the Subspace Tools rebrand.

Updates the single reference in `docs/ai3_token/cross-domain-messaging.mdx`:
- New URL: https://subspace.tools/xdm/transfers/ (verified live, returns 200)
- Names the tool suite ("Subspace Tools") with a link to the site

A repo-wide search confirmed this was the only reference to the old name/URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)