### PR TITLE
docs: fix broken internal links and a dead anchor

### DIFF
--- a/docs/community/contribute/translate.md
+++ b/docs/community/contribute/translate.md
@@ -51,7 +51,7 @@ This guide will walk you through the process of providing translations for this 
 ### Guidelines
 
 - Our goal is to crowdsource translations to support multiple languages. If a translation already exists, please review it instead of creating a duplicate.
-- Ensure you follow our [Contributing Standards](/participate/contribute/translate), and our [Code of Conduct](/participate/contribute/code-of-conduct).
+- Ensure you follow our [Contributing Standards](/community/contribute/translate), and our [Code of Conduct](/community/contribute/code-of-conduct).
 
 ### How-To
 

--- a/docs/farming/cli/cli-farming-cluster.mdx
+++ b/docs/farming/cli/cli-farming-cluster.mdx
@@ -112,7 +112,7 @@ For your cluster to be reachable, open and forward the default port `30533` to t
 
 If you have an IPv6 address but no public IPv4 address, setting the listen port to with `--listen-on "/ip6/::/tcp/<PORT>"`. to accept IPv6 connections is highly recommended.
 
-Refer to our guide on [Port Forwarding](/farming/guides/port-config).
+Refer to our guide on [Port Forwarding](/network/port-config/farming-cluster).
 
 :::
 

--- a/docs/farming/cli/cli-install.mdx
+++ b/docs/farming/cli/cli-install.mdx
@@ -43,7 +43,7 @@ A complete list of parameters and their functions can be obtained using the `--h
 
 :::tip Substrate Address Needed
 
-To use this software, you need a Substrate wallet address. You can use [Talisman](/wallets/talisman) <Badge variant="recommended" text="Recommended" /> or check out other compatible [wallets](/farming-&-staking/wallets).
+To use this software, you need a Substrate wallet address. You can use [Talisman](/wallets/talisman) <Badge variant="recommended" text="Recommended" /> or check out other compatible [wallets](/wallets).
 
 If you have a previous wallet address that starts with `st`, you can still use it, or you can transform it to the new `su` prefix. You can convert your existing wallet address using the tool available at [ss58.org](https://ss58.org). Previously, our testnets used the prefix `2254`, while the Chronos testnet and Autonomys mainnet use the prefix `6094`.
 

--- a/docs/farming/cli/cli-tips.mdx
+++ b/docs/farming/cli/cli-tips.mdx
@@ -225,7 +225,7 @@ Proof-of-Time is secured by Timekeepers, an optional role that has been added to
 - `--timekeeper`: To enable timekeeping on the node
 - `--timekeeper-cpu-cores`: To specify which cores the Timekeeper will run on. 
 
-Read more about [Timekeepers](/farming/timekeeper)
+Read more about [Timekeepers](/timekeeping)
 
 ---
 

--- a/docs/farming/cli/testnet.mdx
+++ b/docs/farming/cli/testnet.mdx
@@ -35,7 +35,7 @@ Currently the only difference between chronos and mainnet is the chain specifica
 
 :::tip Substrate Address Needed
 
-To use this software, you need a Substrate wallet address. You can use [Talisman](/wallets/talisman) <Badge variant="recommended" text="Recommended" /> or check out other compatible [wallets](/farming-&-staking/wallets).
+To use this software, you need a Substrate wallet address. You can use [Talisman](/wallets/talisman) <Badge variant="recommended" text="Recommended" /> or check out other compatible [wallets](/wallets).
 
 If you have a previous wallet address that starts with `st`, you can still use it, or you can transform it to the new `su` prefix. You can convert your existing wallet address using the tool available at [ss58.org](https://ss58.org). Previously, our testnets used the prefix `2254`, while the Chronos testnet and Autonomys mainnet use the prefix `6094`.
 

--- a/docs/farming/common-problems.mdx
+++ b/docs/farming/common-problems.mdx
@@ -33,7 +33,6 @@ This page documents known errors and warnings you may encounter while running Au
 
 ## Quick Navigation
 
-- **[Severity Levels](#severity-levels)** - Understanding error severity indicators
 - **[Program Issues](#program-issues)** - Errors and warnings tied to specific components (Node, Farmer, Farming Cluster)
 - **[Unexpected Behavior](#unexpected-behavior)** - General issues not tied to specific components
 

--- a/docs/farming/intro.mdx
+++ b/docs/farming/intro.mdx
@@ -196,7 +196,7 @@ If you face an error where the node outputs nothing and no error code is given i
 
 :::info Port Forwarding & Firewall Guide
 
-For detailed information on network configurations, including port forwarding requirements and firewall settings, please refer to our [Port Forwarding & Firewall](/farming/guides/port-config) guide.
+For detailed information on network configurations, including port forwarding requirements and firewall settings, please refer to our [Port Forwarding & Firewall](/network) guide.
 
 :::
 
@@ -208,7 +208,7 @@ For detailed information, visit our [Safety and Security](/learn/security) guide
 
 :::
 
-Ensure your system is regularly updated, configure [port forwarding](/farming/guides/port-config#ports-to-forward--firewall-access), set up your [firewall](/farming/guides/port-config#firewall-configuration), and follow best practices for network safety. For comprehensive security guidelines, please refer to our [Safety and Security](/learn/security) guide.
+Ensure your system is regularly updated, configure [port forwarding](/network), set up your [firewall](/network), and follow best practices for network safety. For comprehensive security guidelines, please refer to our [Safety and Security](/learn/security) guide.
 
 ## Wallet
 

--- a/docs/farming/space-acres/install.mdx
+++ b/docs/farming/space-acres/install.mdx
@@ -59,7 +59,7 @@ To learn how to create a Substrate wallet, please visit our pages on [SubWallet 
 
 :::caution Port Forwarding
 To ensure proper communication between Space Acres and other peers, forward ports 30333 and 30433 on your router to the PC running Space Acres.
-For more details, refer to the [Port Forwarding Guide](https://docs.autonomys.xyz/farming/guides/port-config#ports-to-forward--firewall-access).
+For more details, refer to the [Port Forwarding Guide](https://docs.autonomys.xyz/network/port-config/space-acres).
 :::
 
 ### Installation Videos

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -170,4 +170,4 @@ Validate and execute transactions, produce execution receipts, and apply state t
 Run the Proof-of-Time chain and maintain the randomness beacon that secures the consensus chain.
 
 **Getting Started:**
-- **[Start Timekeeping](/farming/timekeeper)** - Contribute to network randomness
+- **[Start Timekeeping](/timekeeping)** - Contribute to network randomness

--- a/docs/learn/faq.mdx
+++ b/docs/learn/faq.mdx
@@ -139,7 +139,7 @@ dsn-listen-on "/ip4/0.0.0.0/tcp/30433"`}
     </Tabs>
     
     <ContentFooter>
-      For more details, including steps to enable port forwarding, refer to the <Link to="/farming/guides/port-config">Ports to Forward &amp; Firewall Access</Link> guide.
+      For more details, including steps to enable port forwarding, refer to the <Link to="/network">Ports to Forward &amp; Firewall Access</Link> guide.
     </ContentFooter>
   </ContentBlock>
 

--- a/docs/learn/security.md
+++ b/docs/learn/security.md
@@ -286,7 +286,7 @@ sudo ufw allow 30533/tcp comment 'Farmer'
 sudo ufw enable
 ```
 
-**Note**: The ports shown above are the standard Autonomys network ports. For detailed information about port forwarding, firewall configuration, and scenarios with multiple nodes, refer to the comprehensive <Link to="/farming/guides/port-config">Port Forwarding & Firewall guide</Link>.
+**Note**: The ports shown above are the standard Autonomys network ports. For detailed information about port forwarding, firewall configuration, and scenarios with multiple nodes, refer to the comprehensive <Link to="/network">Port Forwarding & Firewall guide</Link>.
 
 </ContentBlock>
 


### PR DESCRIPTION
## Summary

Cleans up the broken-link/anchor warnings surfaced by `yarn build`. These were pre-existing on `main` (unrelated to the Subspace Tools guides) and stemmed mostly from links pointing at redirect *sources* or stale pre-reorg paths instead of their live destinations.

## Fixes

| Old (broken) | New |
|---|---|
| `/farming-&-staking/wallets` | `/wallets` |
| `/farming/timekeeper` | `/timekeeping` |
| `/participate/contribute/translate` | `/community/contribute/translate` |
| `/participate/contribute/code-of-conduct` | `/community/contribute/code-of-conduct` |
| `/farming/guides/port-config` | `/network` (general refs) |
| `/farming/guides/port-config` (farming-cluster guide) | `/network/port-config/farming-cluster` |
| `/farming/guides/port-config` (space-acres guide) | `/network/port-config/space-acres` |

Also removed the **Severity Levels** item from the Quick Navigation in `common-problems.mdx` — the page has no such section, so the `#severity-levels` anchor was dead.

Files touched: `docs/farming/cli/{testnet,cli-install,cli-tips,cli-farming-cluster}.mdx`, `docs/farming/{intro,common-problems}.mdx`, `docs/farming/space-acres/install.mdx`, `docs/index.mdx`, `docs/learn/{faq.mdx,security.md}`, `docs/community/contribute/translate.md`.

## Known remaining warnings (false positives, intentionally left)

`#network` and `#farming` (learn/faq) and `#unlock-nominator` (staking/operator/polkadot) still warn. These ids are rendered by the `ContentGroup`/`ContentBlock` components, which Docusaurus's static anchor checker doesn't inspect. They resolve correctly at runtime — verified that `id="network"`, `id="farming"`, and `id="unlock-nominator"` are present in the built HTML. Fixing them would mean restructuring those sections into real markdown headings; out of scope here.

## Notes

- English source docs only. The same warnings appear under each translated locale (`/de/...`, etc.); those will clear on the next Crowdin sync once the source strings update, and editing the generated i18n files directly would be overwritten.

## Testing

- `yarn build` passes on Node 22.14.0; all 10 locale builds succeed. All genuinely broken links/anchors are resolved; only the 3 documented false positives remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Preview test checklist

On the Netlify preview, open each page below and click the named link — it should land on the expected destination (no 404, no "page not found"):

- [x] **Homepage** (`/`) → "Start Timekeeping" → `/timekeeping`
- [x] **`/farming/cli/tips`** → "Timekeepers" link → `/timekeeping`
- [x] **`/farming/cli/testnet`** → "wallets" link → `/wallets`
- [x] **`/farming/cli/install`** → "wallets" link → `/wallets`
- [x] **`/learn/faq`** → "Ports to Forward & Firewall Access" → `/network`
- [x] **`/learn/security`** → "Port Forwarding & Firewall guide" → `/network`
- [x] **`/farming/intro`** → "Port Forwarding & Firewall" → `/network`
- [x] **`/farming/intro`** (Security Considerations) → "port forwarding" and "firewall" links → `/network`
- [x] **`/farming/cli/cluster`** → "Port Forwarding" → `/network/port-config/farming-cluster`
- [x] **`/farming/space-acres/install`** → "Port Forwarding Guide" → `/network/port-config/space-acres`
- [x] **`/community/contribute/translate`** → "Contributing Standards" → `/community/contribute/translate`, and "Code of Conduct" → `/community/contribute/code-of-conduct`
- [x] **`/farming/common-problems`** → Quick Navigation shows only **Program Issues** and **Unexpected Behavior** (no "Severity Levels"); both jump to their sections

Also sanity-check the old redirect still works:
- [x] Visiting `/farming/guides/port-config` directly redirects to `/network`
